### PR TITLE
fix(performance): disable memory recording to reduce overhead

### DIFF
--- a/run_experiment_by_yaml.py
+++ b/run_experiment_by_yaml.py
@@ -13,11 +13,14 @@ from omegaconf import OmegaConf
 
 from stgym.config_schema import ExperimentConfig, MLFlowConfig
 from stgym.rct.run import run_exp
-from stgym.utils import (
-    export_memory_snapshot,
-    start_record_memory_history,
-    stop_record_memory_history,
-)
+
+# Memory recording functions are available in stgym.utils for debugging:
+# from stgym.utils import (
+#     export_memory_snapshot,
+#     start_record_memory_history,
+#     stop_record_memory_history,
+# )
+# To enable memory recording, uncomment the imports above and the function calls below
 
 
 def load_yaml_config(yaml_path: str) -> ExperimentConfig:
@@ -100,10 +103,11 @@ def main():
     # Run experiment
     logger.info("Starting experiment...")
 
-    start_record_memory_history()
+    # Memory recording disabled for performance - uncomment to enable debugging:
+    # start_record_memory_history()
     success = run_exp(exp_cfg, mlflow_cfg)
-    stop_record_memory_history()
-    export_memory_snapshot()
+    # stop_record_memory_history()
+    # export_memory_snapshot()
     if success:
         logger.info("Experiment completed successfully!")
     else:


### PR DESCRIPTION
## Problem

Issue #30 requested removing memory recording functionality to improve performance by reducing unrelated overhead during experiment execution.

## Solution

Disabled CUDA memory recording by commenting out the function calls in `run_experiment_by_yaml.py` while preserving the utility functions in `stgym/utils.py` for future debugging use.

## Changes Made

- Commented out imports of memory recording functions from `stgym.utils`
- Commented out function calls: `start_record_memory_history()`, `stop_record_memory_history()`, and `export_memory_snapshot()`
- Added clear comments explaining how to re-enable memory recording for debugging

## Testing

- Existing functionality preserved - experiments run without memory recording overhead
- Memory recording utilities remain available in `stgym/utils.py` for debugging when needed
- Pre-commit hooks passed (black formatting applied automatically)

## Benefits

- **Performance improvement**: Eliminates CUDA memory recording overhead during normal experiment execution
- **Debugging capability preserved**: Functions remain available and can be easily re-enabled by uncommenting
- **Clear documentation**: Comments explain how to re-enable the functionality when needed

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>