### PR TITLE
Disable CUDA memory caching to fix NVML errors

### DIFF
--- a/run_experiment_by_yaml.py
+++ b/run_experiment_by_yaml.py
@@ -3,6 +3,11 @@
 Script to launch experiments from YAML configuration files.
 """
 
+import os
+
+# Disable CUDA memory caching to prevent NVML errors on virtual GPU environments (#48)
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+
 import argparse
 from pathlib import Path
 

--- a/run_rct.py
+++ b/run_rct.py
@@ -1,3 +1,8 @@
+import os
+
+# Disable CUDA memory caching to prevent NVML errors on virtual GPU environments (#48)
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+
 import hydra
 import pydash as pyd
 import ray


### PR DESCRIPTION
## Summary
- Set `PYTORCH_NO_CUDA_MEMORY_CACHING=1` in `run_rct.py` and `run_experiment_by_yaml.py` to prevent NVML device handle errors on virtual GPU environments
- Reproduction testing (20 runs) confirmed this eliminates the `NVML_SUCCESS == DriverAPI::get()->nvmlDeviceGetHandleByPciBusId_v2_` errors that caused 200 failed runs

Closes #48

## Test plan
- [x] Reproduced 20 failed runs with `PYTORCH_NO_CUDA_MEMORY_CACHING=1` — 0/20 NVML errors (vs 200/200 originally)
- [x] Full sweep run (experiment `589768993371732729`): 704 runs, 0 NVML errors — fix confirmed at scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)