### PR TITLE
fix: run NaN check on CPU before moving dataset to GPU

### DIFF
--- a/stgym/data_loader/__init__.py
+++ b/stgym/data_loader/__init__.py
@@ -243,8 +243,10 @@ class STDataModule(STDataModuleBase):
     """
 
     def __init__(self, task_cfg: TaskConfig, dl_cfg: DataLoaderConfig):
-        self.ds = load_dataset(task_cfg, dl_cfg).to(dl_cfg.device)
+        self.ds = load_dataset(task_cfg, dl_cfg)
+        # Run NaN check on CPU to avoid CUDA OOM for large datasets
         self.check_nan()
+        self.ds = self.ds.to(dl_cfg.device)
         self.loaders = create_loader(self.ds, dl_cfg)
         super().__init__(has_val=True, has_test=True)
 
@@ -253,7 +255,9 @@ class STKfoldDataModule(STDataModuleBase):
     """Data module supporing k-fold cross validation."""
 
     def __init__(self, task_cfg: TaskConfig, dl_cfg: DataLoaderConfig):
-        self.ds = load_dataset(task_cfg, dl_cfg).to(dl_cfg.device)
+        self.ds = load_dataset(task_cfg, dl_cfg)
+        # Run NaN check on CPU to avoid CUDA OOM for large datasets
         self.check_nan()
+        self.ds = self.ds.to(dl_cfg.device)
         self.loaders = create_kfold_loader(self.ds, dl_cfg)
         super().__init__(has_val=True, has_test=True)


### PR DESCRIPTION
## Summary

`check_nan()` ran `torch.isnan(self.ds.x).sum()` on the full dataset after moving to GPU, causing CUDA OOM for large datasets like mouse-kidney (2M spots × 2K features = ~16 GB tensor).

## Fix

Move `check_nan()` before `.to(device)` so it runs on CPU in both `STDataModule` and `STKfoldDataModule`.

## Test plan

- [x] All 181 non-slow tests pass
- [x] Verify mouse-kidney GPU training on cyy2

Relates to #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)