### PR TITLE
fix: disable CUDA memory caching in tests for vGPU

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Disable CUDA memory caching to prevent NVML errors on virtual GPU environments (#48)
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"


### PR DESCRIPTION
## Summary

Closes #64

- Add `tests/conftest.py` that sets `PYTORCH_NO_CUDA_MEMORY_CACHING=1` to prevent segfaults when running tests on virtual GPU environments
- This matches the workaround already used in `run_experiment_by_yaml.py` (see #48)

## Test plan

- [ ] Run `pytest tests/integrated/test_run_exp_with_real_data.py` on cyy2 — should no longer segfault
- [x] Local tests unaffected (env var is a no-op on CPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)