### PR TITLE
fix: reject hierarchical pooling in node-classification configs

### DIFF
--- a/conf/design_space/node_clf.yaml
+++ b/conf/design_space/node_clf.yaml
@@ -4,6 +4,7 @@ defaults:
 
 model:
   global_pooling: null
+  pooling: null
 task:
   type: node-classification
   dataset_name:

--- a/stgym/config_schema.py
+++ b/stgym/config_schema.py
@@ -186,6 +186,25 @@ class NodeClassifierModelConfig(BaseModel):
     # misc
     mem: MemoryConfig = MemoryConfig(inplace=False)
 
+    @model_validator(mode="after")
+    def reject_pooling_for_node_classification(self) -> Self:
+        """Reject any MP layer with hierarchical pooling enabled.
+
+        Hierarchical pooling (DMoN/MinCut) coarsens the graph, reducing the
+        number of nodes. Node classification requires per-node predictions,
+        so pooling is incompatible.
+        """
+        pooling_layers = [mp for mp in self.mp_layers if mp.has_pooling]
+        if pooling_layers:
+            types = [mp.pooling.type for mp in pooling_layers]
+            raise ValueError(
+                f"Node classification requires per-node predictions, but "
+                f"hierarchical pooling {types} coarsens the graph and reduces "
+                f"the node count. Remove pooling from all MP layers for "
+                f"node-classification tasks."
+            )
+        return self
+
 
 class DataLoaderConfig(BaseModel):
     class DataSplitConfig(BaseModel):

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -10,6 +10,7 @@ from stgym.config_schema import (
     LayerConfig,
     MessagePassingConfig,
     MLFlowConfig,
+    NodeClassifierModelConfig,
     PoolingConfig,
     PostMPConfig,
     TaskConfig,
@@ -182,6 +183,30 @@ class TestEdgeWeightPoolingValidation:
                 mp_layers=[
                     self._make_mp_layer(layer_type, with_pooling=True),
                     self._make_mp_layer(layer_type, with_pooling=True),
+                ],
+                post_mp_layer=PostMPConfig(dims=[10]),
+            )
+
+
+class TestNodeClassificationPoolingValidation:
+    """Validate that hierarchical pooling is rejected for node classification."""
+
+    @pytest.mark.parametrize("layer_type", ["gcnconv", "sageconv", "ginconv"])
+    def test_no_pooling_is_valid(self, layer_type):
+        NodeClassifierModelConfig(
+            mp_layers=[MessagePassingConfig(layer_type=layer_type)],
+            post_mp_layer=PostMPConfig(dims=[10]),
+        )
+
+    @pytest.mark.parametrize("pooling_type", ["dmon", "mincut"])
+    def test_pooling_raises(self, pooling_type):
+        with pytest.raises(ValidationError, match="Node classification"):
+            NodeClassifierModelConfig(
+                mp_layers=[
+                    MessagePassingConfig(
+                        layer_type="gcnconv",
+                        pooling=PoolingConfig(type=pooling_type, n_clusters=3),
+                    ),
                 ],
                 post_mp_layer=PostMPConfig(dims=[10]),
             )


### PR DESCRIPTION
## Summary
- Node-classification with hierarchical pooling (DMoN/MinCut) causes batch size mismatch errors because pooling coarsens the graph, reducing node count, while the loss function expects per-node predictions
- Set `pooling: null` in `conf/design_space/node_clf.yaml` to prevent generating invalid configs
- Add `@model_validator` to `NodeClassifierModelConfig` as a safety net to reject pooling at config validation time

Fixes #68

## Test plan
- [x] `TestNodeClassificationPoolingValidation::test_no_pooling_is_valid` passes for gcnconv/sageconv/ginconv
- [x] `TestNodeClassificationPoolingValidation::test_pooling_raises` raises for dmon/mincut

🤖 Generated with [Claude Code](https://claude.com/claude-code)