### PR TITLE
fix: split multirun to exclude hpooling/clusters from node_clf sweep (issue #86)

### DIFF
--- a/scripts/design-dimension-sweep-all.sh
+++ b/scripts/design-dimension-sweep-all.sh
@@ -7,8 +7,9 @@
 #   Custom: RESOURCE=gpu-4 SAMPLE_SIZE=10 ./scripts/design-dimension-sweep-all.sh
 
 # Get all available experiments from conf/exp/*.yaml
-EXPERIMENTS_ALL=$(ls conf/exp/*.yaml | xargs -n1 basename | sed 's/\.yaml$//' | tr '\n' ',' | sed 's/,$//')
-DESIGN_SPACES="graph_clf,node_clf"
+EXPERIMENTS_GRAPH_CLF=$(ls conf/exp/*.yaml | xargs -n1 basename | sed 's/\.yaml$//' | tr '\n' ',' | sed 's/,$//')
+# node_clf design space has pooling: null, so hpooling and clusters dimensions don't exist there
+EXPERIMENTS_NODE_CLF=$(ls conf/exp/*.yaml | grep -v -E '(hpooling|clusters)' | xargs -n1 basename | sed 's/\.yaml$//' | tr '\n' ',' | sed 's/,$//')
 
 # Configuration variables with defaults
 RESOURCE=${RESOURCE:-gpu-6}
@@ -21,13 +22,22 @@ EXPERIMENT_NAME="sweep-all-${DATETIME}"
 echo "Running all design dimensions sweep"
 echo "Resource: $RESOURCE"
 echo "Sample size: $SAMPLE_SIZE"
-echo "Experiments: $EXPERIMENTS_ALL"
-echo "Design spaces: $DESIGN_SPACES"
+echo "Experiments (graph_clf): $EXPERIMENTS_GRAPH_CLF"
+echo "Experiments (node_clf): $EXPERIMENTS_NODE_CLF"
 echo "Experiment name: $EXPERIMENT_NAME"
 
+# graph_clf: all experiments (pooling dimensions are valid)
 time python run_rct.py --multirun \
-       +exp=$EXPERIMENTS_ALL \
-       design_space=$DESIGN_SPACES \
+       +exp=$EXPERIMENTS_GRAPH_CLF \
+       design_space=graph_clf \
+       resource=$RESOURCE \
+       sample_size=$SAMPLE_SIZE \
+       ++mlflow.experiment_name=$EXPERIMENT_NAME
+
+# node_clf: pooling experiments excluded (hpooling/clusters reference model.pooling which is null in node_clf)
+time python run_rct.py --multirun \
+       +exp=$EXPERIMENTS_NODE_CLF \
+       design_space=node_clf \
        resource=$RESOURCE \
        sample_size=$SAMPLE_SIZE \
        ++mlflow.experiment_name=$EXPERIMENT_NAME

--- a/scripts/test-design-dimension-sweep.sh
+++ b/scripts/test-design-dimension-sweep.sh
@@ -13,10 +13,10 @@
 
 # Configuration variables
 # remove 'epochs' experiment for efficiency reasons
-EXPERIMENTS_FULL=$(ls conf/exp/*.yaml | xargs -n1 basename | sed 's/\.yaml$//' | grep -v '^epochs$' | tr '\n' ',' | sed 's/,$//')
+EXPERIMENTS_FULL_GRAPH_CLF=$(ls conf/exp/*.yaml | xargs -n1 basename | sed 's/\.yaml$//' | grep -v '^epochs$' | tr '\n' ',' | sed 's/,$//')
+# node_clf design space has pooling: null, so hpooling and clusters dimensions don't exist there
+EXPERIMENTS_FULL_NODE_CLF=$(ls conf/exp/*.yaml | grep -v -E '(hpooling|clusters)' | xargs -n1 basename | sed 's/\.yaml$//' | grep -v '^epochs$' | tr '\n' ',' | sed 's/,$//')
 EXPERIMENTS_DEBUG="hpooling,bn"
-DESIGN_SPACES="graph_clf,node_clf"
-
 
 # Set mode (default to debug, can be overridden with MODE environment variable)
 MODE=${MODE:-debug}
@@ -24,19 +24,48 @@ MODE=${MODE:-debug}
 RESOURCE=${RESOURCE:-cpu-4}
 
 echo "Mode: $MODE, Resource: $RESOURCE"
-# Select experiment list based on mode
-if [ "$MODE" = "full" ]; then
-    EXPERIMENTS=$EXPERIMENTS_FULL
-    echo "Running in full mode: $EXPERIMENTS with $DESIGN_SPACES"
-else
-    EXPERIMENTS=$EXPERIMENTS_DEBUG
-    echo "Running in debug mode: $EXPERIMENTS with $DESIGN_SPACES"
-fi
 
-time python run_rct.py --multirun \
-       +exp=$EXPERIMENTS \
-       design_space=$DESIGN_SPACES \
-       resource=$RESOURCE \
-       sample_size=5 \
-       design_space.train.max_epoch=2 \
-       ++mlflow.experiment_name=test-sweep-$(date +%m-%d-%Y--%H:%M:%S)
+EXPERIMENT_NAME="test-sweep-$(date +%m-%d-%Y--%H:%M:%S)"
+
+if [ "$MODE" = "full" ]; then
+    echo "Running in full mode"
+    echo "  graph_clf experiments: $EXPERIMENTS_FULL_GRAPH_CLF"
+    echo "  node_clf experiments: $EXPERIMENTS_FULL_NODE_CLF"
+
+    # graph_clf: all experiments (pooling dimensions are valid)
+    time python run_rct.py --multirun \
+           +exp=$EXPERIMENTS_FULL_GRAPH_CLF \
+           design_space=graph_clf \
+           resource=$RESOURCE \
+           sample_size=5 \
+           design_space.train.max_epoch=2 \
+           ++mlflow.experiment_name=$EXPERIMENT_NAME
+
+    # node_clf: pooling experiments excluded (hpooling/clusters reference model.pooling which is null in node_clf)
+    time python run_rct.py --multirun \
+           +exp=$EXPERIMENTS_FULL_NODE_CLF \
+           design_space=node_clf \
+           resource=$RESOURCE \
+           sample_size=5 \
+           design_space.train.max_epoch=2 \
+           ++mlflow.experiment_name=$EXPERIMENT_NAME
+else
+    # Debug mode: hpooling and bn are both valid for graph_clf; only bn is valid for node_clf
+    echo "Running in debug mode: $EXPERIMENTS_DEBUG with graph_clf, then bn with node_clf"
+
+    time python run_rct.py --multirun \
+           +exp=$EXPERIMENTS_DEBUG \
+           design_space=graph_clf \
+           resource=$RESOURCE \
+           sample_size=5 \
+           design_space.train.max_epoch=2 \
+           ++mlflow.experiment_name=$EXPERIMENT_NAME
+
+    time python run_rct.py --multirun \
+           +exp=bn \
+           design_space=node_clf \
+           resource=$RESOURCE \
+           sample_size=5 \
+           design_space.train.max_epoch=2 \
+           ++mlflow.experiment_name=$EXPERIMENT_NAME
+fi


### PR DESCRIPTION
## Summary

- `design-dimension-sweep-all.sh` ran all experiments × both design spaces in a single `--multirun`, but `hpooling` and `clusters` reference `model.pooling.type` / `model.pooling.n_clusters` which don't exist in the `node_clf` design space (`pooling: null`), causing `ValueError: Non-existent design dimension` and silently dropping the entire sweep
- Split into two sequential `run_rct.py` calls: one for `graph_clf` (all experiments) and one for `node_clf` (excluding `hpooling` and `clusters`)
- Applied the same fix to `test-design-dimension-sweep.sh` full mode; debug mode updated to run `bn` only against `node_clf`

Closes #86

## Test plan

- [ ] Verify `EXPERIMENTS_NODE_CLF` excludes `hpooling` and `clusters` (see inline comment below)
- [ ] `pytest tests/ -m 'not slow'` passes (194 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)