### PR TITLE
fix: lock graph_const in knn/radius experiments to eliminate wasted runs (issue #87)

### DIFF
--- a/conf/exp/knn.yaml
+++ b/conf/exp/knn.yaml
@@ -3,5 +3,11 @@
 design_dimension: data_loader.knn_k
 design_choices: [10, 20, 30]  # TODO: increase the span
 
+# Lock graph_const to knn so all sampled configs exercise the knn_k dimension.
+# Without this, ~50% of runs would sample graph_const=radius and knn_k would have no effect.
+design_space:
+  data_loader:
+    graph_const: knn
+
 mlflow:
   experiment_name: knn

--- a/conf/exp/radius.yaml
+++ b/conf/exp/radius.yaml
@@ -3,5 +3,11 @@
 design_dimension: data_loader.radius_ratio
 design_choices: [0.05, 0.075, 0.1]
 
+# Lock graph_const to radius so all sampled configs exercise the radius_ratio dimension.
+# Without this, ~50% of runs would sample graph_const=knn and radius_ratio would have no effect.
+design_space:
+  data_loader:
+    graph_const: radius
+
 mlflow:
   experiment_name: radius

--- a/tests/rct/test_exp_gen.py
+++ b/tests/rct/test_exp_gen.py
@@ -86,3 +86,38 @@ def test_invalid_design_dimension(mock_design_space):
             sample_size=10,
             random_seed=None,
         )
+
+
+@pytest.mark.parametrize(
+    "locked_graph_const, design_dimension, design_choices",
+    [
+        ("knn", "data_loader.knn_k", [10, 20, 30]),
+        ("radius", "data_loader.radius_ratio", [0.05, 0.075, 0.1]),
+    ],
+)
+def test_no_wasted_runs_when_graph_const_is_locked(
+    mock_design_space, locked_graph_const, design_dimension, design_choices
+):
+    """Locking graph_const ensures every run exercises the intended design dimension.
+
+    Reproduces issue #87: when graph_const is free to vary, ~50% of knn/radius
+    experiment runs sample the wrong graph construction method, making the design
+    dimension (knn_k or radius_ratio) irrelevant for those runs.
+    """
+    ds = _.set_(mock_design_space, "data_loader.graph_const", locked_graph_const)
+    exp_cfgs = generate_experiment_configs(
+        ds,
+        design_dimension=design_dimension,
+        design_choices=design_choices,
+        sample_size=10,
+        random_seed=42,
+    )
+
+    for cfg in exp_cfgs:
+        assert cfg.data_loader.graph_const == locked_graph_const
+        if locked_graph_const == "knn":
+            assert cfg.data_loader.radius_ratio is None
+            assert cfg.data_loader.knn_k in design_choices
+        else:
+            assert cfg.data_loader.knn_k is None
+            assert cfg.data_loader.radius_ratio in design_choices


### PR DESCRIPTION
## Problem

`knn.yaml` varies `data_loader.knn_k` as the design dimension, but the full design space samples `graph_const` from `['knn', 'radius']`. ~50% of runs sample `graph_const=radius`, making `knn_k` irrelevant for those runs. The same applies to `radius.yaml` with `radius_ratio`.

## Solution

Add `design_space.data_loader.graph_const` overrides directly in the experiment YAML configs to lock the graph construction method:
- `knn.yaml`: `graph_const: knn`
- `radius.yaml`: `graph_const: radius`

This ensures 100% of sampled configs exercise the intended design dimension.

## Changes Made

- `conf/exp/knn.yaml`: override `design_space.data_loader.graph_const: knn`
- `conf/exp/radius.yaml`: override `design_space.data_loader.graph_const: radius`
- `tests/rct/test_exp_gen.py`: add `test_no_wasted_runs_when_graph_const_is_locked` parametrized for both knn and radius

## Testing

- [x] New test `test_no_wasted_runs_when_graph_const_is_locked` passes for both `knn` and `radius` cases
- [x] `pytest tests/ -m 'not slow'` — 196 passed

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)