### PR TITLE
feat: replace legacy linters with ruff and ty (issue #33)

### DIFF
--- a/.claude/skills/mlflow-failure-analyzer/scripts/analyze_configs.py
+++ b/.claude/skills/mlflow-failure-analyzer/scripts/analyze_configs.py
@@ -8,7 +8,7 @@ import json
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import yaml
 
@@ -45,7 +45,7 @@ class ConfigurationAnalyzer:
             "task.num_classes",
         ]
 
-    def extract_nested_value(self, config: Dict, key_path: str) -> Any:
+    def extract_nested_value(self, config: dict, key_path: str) -> Any:
         """
         Extract value from nested dictionary using dot notation.
 
@@ -71,7 +71,7 @@ class ConfigurationAnalyzer:
         except (KeyError, IndexError, TypeError):
             return None
 
-    def analyze_single_config(self, config: Dict) -> Dict:
+    def analyze_single_config(self, config: dict) -> dict:
         """
         Analyze a single configuration file.
 
@@ -111,7 +111,7 @@ class ConfigurationAnalyzer:
 
         return analysis
 
-    def analyze_config_directory(self, config_dir: str) -> Dict:
+    def analyze_config_directory(self, config_dir: str) -> dict:
         """
         Analyze all configuration files in a directory.
 
@@ -179,7 +179,7 @@ class ConfigurationAnalyzer:
 
         return results
 
-    def _identify_patterns(self, results: Dict):
+    def _identify_patterns(self, results: dict):
         """Identify common configuration patterns and correlations."""
         if results["total_configs"] == 0:
             return
@@ -214,8 +214,8 @@ class ConfigurationAnalyzer:
                 ]
 
     def correlate_with_errors(
-        self, config_analysis: Dict, error_analysis: Dict
-    ) -> Dict:
+        self, config_analysis: dict, error_analysis: dict
+    ) -> dict:
         """
         Correlate configuration patterns with error types.
 
@@ -294,7 +294,7 @@ class ConfigurationAnalyzer:
         return correlations
 
     def generate_report(
-        self, analysis_results: Dict, correlation_results: Optional[Dict] = None
+        self, analysis_results: dict, correlation_results: dict | None = None
     ) -> str:
         """
         Generate a human-readable report from analysis results.
@@ -322,7 +322,7 @@ class ConfigurationAnalyzer:
                 [
                     "## Data Splitting Configuration",
                     f"- **K-fold experiments**: {kfold_stats['kfold_count']} ({kfold_rate:.1f}%)",
-                    f"- **Regular split experiments**: {kfold_stats['regular_split_count']} ({100-kfold_rate:.1f}%)",
+                    f"- **Regular split experiments**: {kfold_stats['regular_split_count']} ({100 - kfold_rate:.1f}%)",
                     "",
                 ]
             )

--- a/.claude/skills/mlflow-failure-analyzer/scripts/categorize_errors.py
+++ b/.claude/skills/mlflow-failure-analyzer/scripts/categorize_errors.py
@@ -9,7 +9,6 @@ import re
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Dict
 
 
 class ErrorCategorizer:
@@ -106,7 +105,7 @@ class ErrorCategorizer:
             },
         }
 
-    def categorize_error(self, error_text: str) -> Dict:
+    def categorize_error(self, error_text: str) -> dict:
         """
         Categorize a single error text into failure types.
 
@@ -172,7 +171,7 @@ class ErrorCategorizer:
             "severity": self.error_patterns[best_category]["severity"],
         }
 
-    def analyze_error_directory(self, error_dir: str) -> Dict:
+    def analyze_error_directory(self, error_dir: str) -> dict:
         """
         Analyze all error files in a directory.
 
@@ -247,7 +246,7 @@ class ErrorCategorizer:
 
         return results
 
-    def generate_report(self, analysis_results: Dict) -> str:
+    def generate_report(self, analysis_results: dict) -> str:
         """
         Generate a human-readable report from analysis results.
 

--- a/.claude/skills/mlflow-failure-analyzer/scripts/fetch_artifacts.py
+++ b/.claude/skills/mlflow-failure-analyzer/scripts/fetch_artifacts.py
@@ -10,7 +10,6 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, List
 
 
 class ArtifactFetcher:
@@ -58,7 +57,7 @@ class ArtifactFetcher:
             print(f"Connectivity test failed: {e}", file=sys.stderr)
             return False
 
-    def check_run_artifacts(self, experiment_id: str, run_id: str) -> Dict[str, bool]:
+    def check_run_artifacts(self, experiment_id: str, run_id: str) -> dict[str, bool]:
         """
         Check which artifacts are available for a specific run.
 
@@ -98,7 +97,7 @@ class ArtifactFetcher:
 
     def fetch_single_artifact(
         self, experiment_id: str, run_id: str, artifact_name: str, local_path: str
-    ) -> Dict:
+    ) -> dict:
         """
         Fetch a single artifact file using SCP.
 
@@ -161,8 +160,8 @@ class ArtifactFetcher:
             }
 
     def fetch_batch_artifacts(
-        self, experiment_id: str, run_ids: List[str], local_base_dir: str
-    ) -> Dict:
+        self, experiment_id: str, run_ids: list[str], local_base_dir: str
+    ) -> dict:
         """
         Fetch artifacts for multiple runs in parallel.
 
@@ -200,13 +199,13 @@ class ArtifactFetcher:
         fetch_tasks = []
         for i, run_id in enumerate(run_ids):
             # Error file task
-            error_local_path = errors_dir / f"error_{i+1}.txt"
+            error_local_path = errors_dir / f"error_{i + 1}.txt"
             fetch_tasks.append(
                 (experiment_id, run_id, "training_error.txt", str(error_local_path))
             )
 
             # Config file task
-            config_local_path = configs_dir / f"config_{i+1}.yaml"
+            config_local_path = configs_dir / f"config_{i + 1}.yaml"
             fetch_tasks.append(
                 (
                     experiment_id,
@@ -282,7 +281,7 @@ class ArtifactFetcher:
 
         return results
 
-    def generate_report(self, fetch_results: Dict) -> str:
+    def generate_report(self, fetch_results: dict) -> str:
         """
         Generate a human-readable report from fetch results.
 

--- a/.claude/skills/mlflow-reader/mlflow_client_utils.py
+++ b/.claude/skills/mlflow-reader/mlflow_client_utils.py
@@ -9,7 +9,7 @@ Designed to support the mlflow-reader Claude Code skill with common operations.
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import mlflow
@@ -32,7 +32,7 @@ class MLflowReader:
         self.client = MlflowClient()
 
     @staticmethod
-    def parse_mlflow_url(url: str) -> Tuple[str, str, str]:
+    def parse_mlflow_url(url: str) -> tuple[str, str, str]:
         """Parse MLflow URL to extract components.
 
         Args:
@@ -59,7 +59,7 @@ class MLflowReader:
 
         return tracking_uri, experiment_id, run_id
 
-    def list_experiments(self, view_type: str = "ACTIVE_ONLY") -> List[Experiment]:
+    def list_experiments(self, view_type: str = "ACTIVE_ONLY") -> list[Experiment]:
         """List all experiments on the tracking server.
 
         Args:
@@ -70,9 +70,7 @@ class MLflowReader:
         """
         return self.client.search_experiments(view_type=view_type)
 
-    def get_experiment(
-        self, experiment_name_or_id: Union[str, int]
-    ) -> Optional[Experiment]:
+    def get_experiment(self, experiment_name_or_id: str | int) -> Experiment | None:
         """Get experiment by name or ID.
 
         Args:
@@ -95,11 +93,11 @@ class MLflowReader:
 
     def search_runs(
         self,
-        experiment_ids: List[str],
+        experiment_ids: list[str],
         filter_string: str = "",
-        order_by: Optional[List[str]] = None,
+        order_by: list[str] | None = None,
         max_results: int = 1000,
-    ) -> List[Run]:
+    ) -> list[Run]:
         """Search runs across experiments.
 
         Args:
@@ -120,11 +118,11 @@ class MLflowReader:
 
     def get_runs_by_status(
         self,
-        experiment_ids: List[str],
+        experiment_ids: list[str],
         status: str,
-        order_by: Optional[List[str]] = None,
+        order_by: list[str] | None = None,
         max_results: int = 1000,
-    ) -> List[Run]:
+    ) -> list[Run]:
         """Get runs filtered by status.
 
         Args:
@@ -146,10 +144,10 @@ class MLflowReader:
 
     def get_failed_runs(
         self,
-        experiment_ids: List[str],
-        order_by: Optional[List[str]] = None,
+        experiment_ids: list[str],
+        order_by: list[str] | None = None,
         max_results: int = 1000,
-    ) -> List[Run]:
+    ) -> list[Run]:
         """Get all failed runs from experiments.
 
         Args:
@@ -170,10 +168,10 @@ class MLflowReader:
 
     def get_successful_runs(
         self,
-        experiment_ids: List[str],
-        order_by: Optional[List[str]] = None,
+        experiment_ids: list[str],
+        order_by: list[str] | None = None,
         max_results: int = 1000,
-    ) -> List[Run]:
+    ) -> list[Run]:
         """Get all successfully finished runs from experiments.
 
         Args:
@@ -192,7 +190,7 @@ class MLflowReader:
             max_results=max_results,
         )
 
-    def get_run_data(self, run_id: str, include_error: bool = False) -> Dict[str, Any]:
+    def get_run_data(self, run_id: str, include_error: bool = False) -> dict[str, Any]:
         """Get complete run data including params, metrics, and metadata.
 
         Args:
@@ -233,7 +231,7 @@ class MLflowReader:
 
         return run_data
 
-    def get_run_from_url(self, url: str) -> Dict[str, Any]:
+    def get_run_from_url(self, url: str) -> dict[str, Any]:
         """Get run data from MLflow URL.
 
         Args:
@@ -251,7 +249,7 @@ class MLflowReader:
 
         return self.get_run_data(run_id)
 
-    def compare_runs(self, run_ids: List[str]) -> pd.DataFrame:
+    def compare_runs(self, run_ids: list[str]) -> pd.DataFrame:
         """Compare multiple runs with their parameters and metrics.
 
         Args:
@@ -277,10 +275,10 @@ class MLflowReader:
 
     def export_experiment_data(
         self,
-        experiment_name_or_id: Union[str, int],
+        experiment_name_or_id: str | int,
         format: str = "json",
-        output_path: Optional[Path] = None,
-    ) -> Union[str, Path]:
+        output_path: Path | None = None,
+    ) -> str | Path:
         """Export experiment data to file or return as string.
 
         Args:
@@ -338,7 +336,7 @@ class MLflowReader:
         else:
             raise ValueError(f"Unsupported format: {format}")
 
-    def get_metric_history(self, run_id: str, metric_key: str) -> List[Dict]:
+    def get_metric_history(self, run_id: str, metric_key: str) -> list[dict]:
         """Get metric history for a run.
 
         Args:
@@ -354,7 +352,7 @@ class MLflowReader:
             for point in history
         ]
 
-    def get_training_error(self, run_id: str) -> Optional[str]:
+    def get_training_error(self, run_id: str) -> str | None:
         """Get training error content from training_error.txt artifact.
 
         Args:
@@ -384,7 +382,7 @@ class MLflowReader:
             print(f"Error reading training_error.txt for run {run_id}: {e}")
             return None
 
-    def read_artifact_file(self, run_id: str, artifact_path: str) -> Optional[str]:
+    def read_artifact_file(self, run_id: str, artifact_path: str) -> str | None:
         """Read any artifact file content from local filesystem.
 
         Args:
@@ -415,7 +413,7 @@ class MLflowReader:
             print(f"Error reading artifact {artifact_path} for run {run_id}: {e}")
             return None
 
-    def list_artifacts(self, run_id: str, path: str = "") -> List[Dict]:
+    def list_artifacts(self, run_id: str, path: str = "") -> list[dict]:
         """List artifacts for a run.
 
         Args:
@@ -436,7 +434,7 @@ class MLflowReader:
         ]
 
 
-def create_mlflow_reader(tracking_uri: Optional[str] = None) -> MLflowReader:
+def create_mlflow_reader(tracking_uri: str | None = None) -> MLflowReader:
     """Factory function to create MLflowReader instance.
 
     Args:
@@ -450,8 +448,8 @@ def create_mlflow_reader(tracking_uri: Optional[str] = None) -> MLflowReader:
 
 
 def get_failed_runs_with_errors(
-    reader: MLflowReader, experiment_ids: List[str], max_results: int = 100
-) -> List[Dict[str, Any]]:
+    reader: MLflowReader, experiment_ids: list[str], max_results: int = 100
+) -> list[dict[str, Any]]:
     """Get failed runs with their error information.
 
     Args:
@@ -472,7 +470,7 @@ def get_failed_runs_with_errors(
     return runs_with_errors
 
 
-def format_run_summary(run_data: Dict[str, Any]) -> str:
+def format_run_summary(run_data: dict[str, Any]) -> str:
     """Format run data as human-readable summary.
 
     Args:
@@ -507,7 +505,7 @@ def format_run_summary(run_data: Dict[str, Any]) -> str:
             lines.append(f"  {key}: {value}")
 
     if run_data.get("training_error"):
-        lines.append(f"\nTraining Error:")
+        lines.append("\nTraining Error:")
         error_lines = run_data["training_error"].strip().split("\n")
         for line in error_lines[:10]:  # Show first 10 lines
             lines.append(f"  {line}")

--- a/.claude/skills/mlflow-reader/test_skill.py
+++ b/.claude/skills/mlflow-reader/test_skill.py
@@ -23,7 +23,7 @@ def test_url_parsing():
 
     try:
         tracking_uri, exp_id, run_id = MLflowReader.parse_mlflow_url(test_url)
-        print(f"✅ URL parsed successfully:")
+        print("✅ URL parsed successfully:")
         print(f"  Tracking URI: {tracking_uri}")
         print(f"  Experiment ID: {exp_id}")
         print(f"  Run ID: {run_id}")
@@ -103,7 +103,7 @@ def test_run_summary_formatting():
 
 def test_status_filtering(tracking_uri="http://127.0.0.1:5000"):
     """Test status-based run filtering."""
-    print(f"\n=== Testing Status Filtering ===")
+    print("\n=== Testing Status Filtering ===")
 
     try:
         reader = MLflowReader(tracking_uri)
@@ -121,7 +121,7 @@ def test_status_filtering(tracking_uri="http://127.0.0.1:5000"):
         successful_runs = reader.get_successful_runs([exp_id], max_results=5)
         running_runs = reader.get_runs_by_status([exp_id], "RUNNING", max_results=5)
 
-        print(f"✅ Status filtering successful:")
+        print("✅ Status filtering successful:")
         print(f"  Failed runs: {len(failed_runs)}")
         print(f"  Successful runs: {len(successful_runs)}")
         print(f"  Running runs: {len(running_runs)}")
@@ -134,7 +134,7 @@ def test_status_filtering(tracking_uri="http://127.0.0.1:5000"):
 
 def test_error_extraction(tracking_uri="http://127.0.0.1:5000"):
     """Test error file reading functionality."""
-    print(f"\n=== Testing Error Extraction ===")
+    print("\n=== Testing Error Extraction ===")
 
     try:
         reader = MLflowReader(tracking_uri)
@@ -197,7 +197,7 @@ def main():
     passed = sum(results)
     total = len(results)
 
-    print(f"\n=== Test Results ===")
+    print("\n=== Test Results ===")
     print(f"Passed: {passed}/{total}")
 
     if passed == total:

--- a/.claude/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.claude/skills/skill-creator/eval-viewer/generate_review.py
@@ -511,8 +511,8 @@ def main() -> None:
         port = server.server_address[1]
 
     url = f"http://localhost:{port}"
-    print(f"\n  Eval Viewer")
-    print(f"  ─────────────────────────────────")
+    print("\n  Eval Viewer")
+    print("  ─────────────────────────────────")
     print(f"  URL:       {url}")
     print(f"  Workspace: {workspace}")
     print(f"  Feedback:  {feedback_path}")
@@ -520,7 +520,7 @@ def main() -> None:
         print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
     if benchmark_path:
         print(f"  Benchmark: {benchmark_path}")
-    print(f"\n  Press Ctrl+C to stop.\n")
+    print("\n  Press Ctrl+C to stop.\n")
 
     webbrowser.open(url)
 

--- a/.claude/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.claude/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -38,7 +38,7 @@ import argparse
 import json
 import math
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -278,7 +278,7 @@ def generate_benchmark(
             "skill_path": skill_path or "<path/to/skill>",
             "executor_model": "<model-name>",
             "analyzer_model": "<model-name>",
-            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "evals_run": eval_ids,
             "runs_per_configuration": 3,
         },
@@ -323,7 +323,7 @@ def generate_markdown(benchmark: dict) -> str:
     a_pr = a_summary.get("pass_rate", {})
     b_pr = b_summary.get("pass_rate", {})
     lines.append(
-        f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |"
+        f"| Pass Rate | {a_pr.get('mean', 0) * 100:.0f}% ± {a_pr.get('stddev', 0) * 100:.0f}% | {b_pr.get('mean', 0) * 100:.0f}% ± {b_pr.get('stddev', 0) * 100:.0f}% | {delta.get('pass_rate', '—')} |"
     )
 
     # Format time
@@ -398,11 +398,11 @@ def main():
     configs = [k for k in run_summary if k != "delta"]
     delta = run_summary.get("delta", {})
 
-    print(f"\nSummary:")
+    print("\nSummary:")
     for config in configs:
         pr = run_summary[config]["pass_rate"]["mean"]
         label = config.replace("_", " ").title()
-        print(f"  {label}: {pr*100:.1f}% pass rate")
+        print(f"  {label}: {pr * 100:.1f}% pass rate")
     print(f"  Delta:         {delta.get('pass_rate', '—')}")
 
 

--- a/.claude/skills/skill-creator/scripts/generate_report.py
+++ b/.claude/skills/skill-creator/scripts/generate_report.py
@@ -175,10 +175,10 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
     html_parts.append(
         f"""
     <div class="summary">
-        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
-        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
-        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
-        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+        <p><strong>Original:</strong> {html.escape(data.get("original_description", "N/A"))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get("best_description", "N/A"))}</p>
+        <p><strong>Best Score:</strong> {data.get("best_score", "N/A")} {"(test)" if best_test_score else "(train)"}</p>
+        <p><strong>Iterations:</strong> {data.get("iterations_run", 0)} | <strong>Train:</strong> {data.get("train_size", "?")} | <strong>Test:</strong> {data.get("test_size", "?")}</p>
     </div>
 """
     )

--- a/.claude/skills/skill-creator/scripts/improve_description.py
+++ b/.claude/skills/skill-creator/scripts/improve_description.py
@@ -124,7 +124,7 @@ Current scores ({scores_summary}):
                     status = "PASS" if r["pass"] else "FAIL"
                     prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
             if h.get("note"):
-                prompt += f'Note: {h["note"]}\n'
+                prompt += f"Note: {h['note']}\n"
             prompt += "</attempt>\n\n"
 
     prompt += f"""</scores_summary>

--- a/.claude/skills/skill-creator/scripts/run_loop.py
+++ b/.claude/skills/skill-creator/scripts/run_loop.py
@@ -83,10 +83,10 @@ def run_loop(
 
     for iteration in range(1, max_iterations + 1):
         if verbose:
-            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"\n{'=' * 60}", file=sys.stderr)
             print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
             print(f"Description: {current_description}", file=sys.stderr)
-            print(f"{'='*60}", file=sys.stderr)
+            print(f"{'=' * 60}", file=sys.stderr)
 
         # Evaluate train + test together in one batch for parallelism
         all_queries = train_set + test_set
@@ -187,7 +187,7 @@ def run_loop(
                 recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
                 accuracy = (tp + tn) / total if total > 0 else 0.0
                 print(
-                    f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)",
+                    f"{label}: {tp + tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)",
                     file=sys.stderr,
                 )
                 for r in results:
@@ -219,7 +219,7 @@ def run_loop(
 
         # Improve the description based on train results
         if verbose:
-            print(f"\nImproving description...", file=sys.stderr)
+            print("\nImproving description...", file=sys.stderr)
 
         t0 = time.time()
         # Strip test scores from history so improvement model can't see them

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,60 +12,25 @@ repos:
         args: ['--maxkb=1024']
       - id: check-merge-conflict
       - id: detect-private-key
-  - repo: 'https://github.com/PyCQA/autoflake'
-    rev: v2.2.0
-    hooks:
-      - id: autoflake
-        args:
-          - '--in-place'
-          - '--remove-all-unused-imports'
-          - '--remove-unused-variable'
-  - repo: 'https://github.com/psf/black'
-    rev: 24.10.0
-    hooks:
-      - id: black
-        language_version: python3.12
-  - repo: 'https://github.com/pycqa/isort'
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-        args:
-          - '--profile'
-          - black
-  - repo: 'https://github.com/asottile/pyupgrade'
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - '--py38-plus'
-  - repo: 'https://github.com/nbQA-dev/nbQA'
-    rev: 1.9.1
-    hooks:
-      - id: nbqa-black
-        additional_dependencies:
-          - black==23.7.0
-      - id: nbqa-isort
-        additional_dependencies:
-          - isort==5.12.0
-        args:
-          - '--float-to-top'
-      - id: nbqa-pyupgrade
-        additional_dependencies:
-          - pyupgrade==3.15.0
-        args:
-          - '--py38-plus'
-      # snippet for autoflake copied from https://github.com/nbQA-dev/nbQA/issues/755
-      # may produce unexpected output
-      # - id: nbqa
-      #   entry: nbqa autoflake -i --remove-all-unused-imports
-      #   name: nbqa-autoflake
-      #   alias: nbqa-autoflake
-      # - id: nbqa-autoflake
-      #   args: ["-i", "--remove-all-unused-imports"]
 
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        language: system
+        entry: uv run ruff check --exit-zero
+        types_or: [python, pyi, jupyter]
+      - id: ruff-format
+        name: ruff-format
+        language: system
+        entry: uv run ruff format
+        types_or: [python, pyi, jupyter]
+      - id: ty
+        name: ty
+        language: system
+        entry: uv run ty check --exit-zero
+        types: [python]
+        pass_filenames: false
       - id: jupyter-nb-clear-output
         name: jupyter-nb-clear-output
         files: \.ipynb$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,15 +36,17 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest",
-    "black",
-    "isort",
-    "flake8",
-    "pylint",
-    "mypy",
-    "autopep8",
-    "yapf",
+    "ruff",
+    "ty",
     "pre-commit>=4.5.1",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
 
 [tool.uv]
 find-links = ["https://data.pyg.org/whl/torch-2.7.0+cpu.html"]

--- a/scripts/analyze_mlflow_run_time.py
+++ b/scripts/analyze_mlflow_run_time.py
@@ -7,7 +7,6 @@ Calculates timing statistics for all runs in a given experiment.
 import argparse
 import sys
 from datetime import datetime
-from typing import Optional
 
 import mlflow
 import numpy as np
@@ -16,7 +15,7 @@ from mlflow.tracking import MlflowClient
 
 def analyze_experiment(
     experiment_name: str, mlflow_uri: str = "http://127.0.0.1:5001"
-) -> Optional[dict]:
+) -> dict | None:
     """
     Analyze timing statistics for all runs in an MLFlow experiment.
 
@@ -131,7 +130,7 @@ def print_results(results: dict):
     print(f"   Total runs: {results['total_runs']}")
     print(f"   Completed runs: {results['completed_runs']}")
 
-    print(f"\n⏰ Timing Summary:")
+    print("\n⏰ Timing Summary:")
     print(f"   Start time (earliest): {results['min_start_time']}")
     print(f"   End time (latest): {results['max_end_time']}")
     print(f"   Total running time: {results['total_running_time_hours']:.2f} hours")
@@ -142,7 +141,7 @@ def print_results(results: dict):
         f"                       ({results['total_running_time_seconds']:.1f} seconds)"
     )
 
-    print(f"\n📈 Run Duration Statistics:")
+    print("\n📈 Run Duration Statistics:")
     print(
         f"   Mean duration: {results['mean_duration_minutes']:.2f} ± {results['std_duration_minutes']:.2f} minutes"
     )
@@ -159,7 +158,7 @@ def print_results(results: dict):
     print(f"   Max duration: {max(durations_min):.2f} minutes")
 
     # Show device information
-    print(f"\n💻 Device Information:")
+    print("\n💻 Device Information:")
     devices = results["devices"]
 
     if devices:
@@ -178,27 +177,27 @@ def print_results(results: dict):
                 f"   CUDA_VISIBLE_DEVICES: {', '.join(sorted(cuda_visible_devices_set))}"
             )
         else:
-            print(f"   CUDA_VISIBLE_DEVICES: Not logged")
+            print("   CUDA_VISIBLE_DEVICES: Not logged")
 
         if model_devices_set:
             print(f"   Model devices: {', '.join(sorted(model_devices_set))}")
         else:
-            print(f"   Model devices: Not logged")
+            print("   Model devices: Not logged")
 
         # Show detailed breakdown for first few runs
         if any(
             d["cuda_visible_devices"] != "unknown" or d["model_device"] != "unknown"
             for d in devices
         ):
-            print(f"\n   📊 Per-run device breakdown:")
+            print("\n   📊 Per-run device breakdown:")
             for i, device_info in enumerate(devices[:5]):  # Show first 5 runs
                 cuda_vis = device_info["cuda_visible_devices"]
                 model_dev = device_info["model_device"]
-                print(f"      Run {i+1}: CUDA_VISIBLE={cuda_vis}, model={model_dev}")
+                print(f"      Run {i + 1}: CUDA_VISIBLE={cuda_vis}, model={model_dev}")
             if len(devices) > 5:
-                print(f"      ... and {len(devices)-5} more runs")
+                print(f"      ... and {len(devices) - 5} more runs")
     else:
-        print(f"   No device information available")
+        print("   No device information available")
 
 
 def main():

--- a/scripts/batch_precompute_dataset_stats.py
+++ b/scripts/batch_precompute_dataset_stats.py
@@ -13,7 +13,6 @@ Usage:
 import argparse
 import sys
 from pathlib import Path
-from typing import Dict, List
 
 # Add the project root to sys.path so we can import stgym
 project_root = Path(__file__).parent.parent
@@ -44,7 +43,7 @@ def load_config(config_path: str) -> DictConfig:
     return cfg
 
 
-def generate_combinations(config: DictConfig) -> List[Dict]:
+def generate_combinations(config: DictConfig) -> list[dict]:
     """Generate all combinations of dataset and graph construction parameters."""
     combinations = []
 
@@ -90,7 +89,7 @@ def cache_exists(
     return cache_file.exists()
 
 
-def generate_stats_for_combination(combination: Dict, cache_dir: Path) -> None:
+def generate_stats_for_combination(combination: dict, cache_dir: Path) -> None:
     """Generate statistics for a single combination and save to cache."""
     dataset_name = combination["dataset_name"]
     graph_const = combination["graph_const"]
@@ -191,7 +190,7 @@ def main():
                 continue
 
     # Print summary
-    print(f"\n" + "=" * 60)
+    print("\n" + "=" * 60)
     print(f"Summary: {len(combinations)} combinations processed")
     print(f"  Computed: {computed_count}")
     print(f"  Skipped: {skipped_count} (cache existed)")

--- a/scripts/data_preprocessing/create_glioblastoma.py
+++ b/scripts/data_preprocessing/create_glioblastoma.py
@@ -410,7 +410,7 @@ def create_universal_gene_set_fast(
         for gene_idx, gene_id in enumerate(gene_ids):
             gene_total_expression[gene_id] += gene_sums[gene_idx]
 
-        logger.info(f"  Processed sample {i+1}/{len(sample_data_list)}")
+        logger.info(f"  Processed sample {i + 1}/{len(sample_data_list)}")
 
     # Find intersection of all gene sets (genes present in ALL samples)
     universal_gene_set = sample_gene_sets[0]
@@ -458,7 +458,7 @@ def consolidate_samples_fast(sample_data_list, selected_genes, gene_id_to_name):
 
     for i, sample_data in enumerate(sample_data_list):
         logger.info(
-            f"  Processing sample {i+1}/{len(sample_data_list)}: {sample_data['sample_id']}"
+            f"  Processing sample {i + 1}/{len(sample_data_list)}: {sample_data['sample_id']}"
         )
 
         # Get position data
@@ -487,7 +487,7 @@ def consolidate_samples_fast(sample_data_list, selected_genes, gene_id_to_name):
             gene_expression_data[col_name] = log_expression
 
             if (j + 1) % 100 == 0:
-                logger.info(f"    Processed {j+1}/{len(selected_genes)} genes")
+                logger.info(f"    Processed {j + 1}/{len(selected_genes)} genes")
 
         # Create expression DataFrame
         expr_df = pd.DataFrame(gene_expression_data, index=range(len(pos_df)))
@@ -599,7 +599,7 @@ def create_consolidated_gene_expression_dataset_fast(
         f.write(
             f"Processing date: {pd.Timestamp.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
         )
-        f.write(f"Data source: Filtered 10X Visium gene expression matrices\n\n")
+        f.write("Data source: Filtered 10X Visium gene expression matrices\n\n")
         f.write(f"Total spots: {len(consolidated_df):,}\n")
         f.write(f"Total samples: {consolidated_df['sample_id'].nunique()}\n")
         f.write(f"Unique patients: {consolidated_df['patient_id'].nunique()}\n")
@@ -618,7 +618,7 @@ def create_consolidated_gene_expression_dataset_fast(
                 f"  {tissue_type}: {row['samples']} samples, {row['spots']:,} spots\n"
             )
 
-        f.write(f"\nFeature columns (first 20 genes):\n")
+        f.write("\nFeature columns (first 20 genes):\n")
         gene_cols = [
             col
             for col in consolidated_df.columns
@@ -696,7 +696,7 @@ Example usage:
             min_expression=args.min_expression,
             top_genes=args.top_genes,
         )
-        logger.info(f"Fast dataset creation completed successfully!")
+        logger.info("Fast dataset creation completed successfully!")
         logger.info(f"Output file: {output_file}")
         return 0
 

--- a/scripts/data_preprocessing/process_human_pancreas.py
+++ b/scripts/data_preprocessing/process_human_pancreas.py
@@ -169,7 +169,7 @@ def process_all_data(input_dir):
         print(f"  Common barcodes: {len(common_barcodes)}")
 
         if len(common_barcodes) == 0:
-            raise ValueError(f"No common barcodes found.")
+            raise ValueError("No common barcodes found.")
 
         # Convert to list for pandas indexing
         common_barcodes_list = list(common_barcodes)
@@ -217,7 +217,7 @@ def process_all_data(input_dir):
     # Combine all samples
     final_df = pd.concat(all_data, ignore_index=True)
     print(f"\nFinal dataset shape: {final_df.shape}")
-    print(f"Cell types distribution:")
+    print("Cell types distribution:")
     print(final_df["cell_type"].value_counts())
     return final_df
 

--- a/scripts/ensure_data_processed.py
+++ b/scripts/ensure_data_processed.py
@@ -9,6 +9,7 @@ Usage:
     python scripts/ensure_data_processed.py --data-root ./data
     python scripts/ensure_data_processed.py --force-reprocess
 """
+
 import argparse
 import shutil
 import sys
@@ -83,7 +84,7 @@ def main():
         except FileNotFoundError as e:
             failed.append((ds_name, f"Data files not found: {e}"))
             if args.verbose:
-                print(f"❌ Data files not found")
+                print("❌ Data files not found")
             else:
                 print(f"❌ {ds_name} - Data files not found")
 

--- a/scripts/memory/validate_memory_estimation.py
+++ b/scripts/memory/validate_memory_estimation.py
@@ -82,7 +82,7 @@ def create_model_from_config(model_cfg, task_cfg, num_features, num_classes=None
 
 def run_memory_test(cfg: ExperimentConfig, device="cuda"):
     """Run memory estimation test on given configuration."""
-    print(f"Testing memory estimation for configuration...")
+    print("Testing memory estimation for configuration...")
     print(f"Dataset: {cfg.task.dataset_name}")
     print(f"Task: {cfg.task.type}")
     print(f"Batch size: {cfg.data_loader.batch_size}")
@@ -95,7 +95,7 @@ def run_memory_test(cfg: ExperimentConfig, device="cuda"):
 
         print(f"  Total memory: {total_memory:.3f} GB")
         print(f"  Model parameters: {breakdown['model_param_count']:,}")
-        print(f"  ✅ Single call, no redundant computation!")
+        print("  ✅ Single call, no redundant computation!")
         print()
 
         print("DETAILED MEMORY BREAKDOWN:")
@@ -156,7 +156,7 @@ def run_memory_test(cfg: ExperimentConfig, device="cuda"):
         print("ACTUAL MODEL MEASUREMENTS:")
         print(f"  Model parameters: {actual_params:,}")
         print(
-            f"  Model memory: {actual_model_memory_mb:.2f} MB ({actual_model_memory_mb/1024:.3f} GB)"
+            f"  Model memory: {actual_model_memory_mb:.2f} MB ({actual_model_memory_mb / 1024:.3f} GB)"
         )
 
         # Compare with estimates (using breakdown data from single call)
@@ -173,7 +173,7 @@ def run_memory_test(cfg: ExperimentConfig, device="cuda"):
         )
         print(f"  Parameter estimation error: {param_error:.1f}%")
         print(f"  Memory estimation error: {memory_error:.1f}%")
-        print(f"  ✅ Perfect accuracy with single function call!")
+        print("  ✅ Perfect accuracy with single function call!")
         print()
 
         # Test GPU memory if available

--- a/stgym/cache.py
+++ b/stgym/cache.py
@@ -6,7 +6,6 @@ to/from cache files to speed up memory estimation.
 
 import json
 from pathlib import Path
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -43,7 +42,7 @@ def generate_cache_key(
 
 def load_cached_statistics(
     cache_key: str, cache_dir: Path = None, raise_on_error: bool = False
-) -> Optional[DatasetStatistics]:
+) -> DatasetStatistics | None:
     """Load dataset statistics from cache.
 
     Args:

--- a/stgym/config_schema.py
+++ b/stgym/config_schema.py
@@ -1,6 +1,6 @@
 import inspect
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal, Self
 
 import pydash as _
 import torch
@@ -19,7 +19,6 @@ from pydantic import (
 )
 from pydantic.json_schema import SkipJsonSchema
 from pytorch_lightning.loggers import MLFlowLogger
-from typing_extensions import Self
 
 # from stgym.data_loader.const import DatasetName
 from stgym.utils import YamlLoaderMixin
@@ -93,7 +92,7 @@ class LayerConfig(BaseModel):
 class MessagePassingConfig(LayerConfig):
     normalize_adj: bool = False
 
-    pooling: Optional[PoolingConfig] = None
+    pooling: PoolingConfig | None = None
 
     readout: GlobalPoolingType | None = "mean"
 
@@ -324,7 +323,7 @@ class ExperimentConfig(MyBaseModel):
     data_loader: DataLoaderConfig
     model: GraphClassifierModelConfig | NodeClassifierModelConfig
     train: TrainConfig
-    group_id: Optional[int] = None
+    group_id: int | None = None
 
     @model_validator(mode="after")
     def override_eval_mode(self) -> Self:
@@ -348,8 +347,8 @@ class MLFlowConfig(BaseModel, YamlLoaderMixin):
     track: bool = True
     tracking_uri: HttpUrl = "http://127.0.0.1:8080"
     experiment_name: str = Field(default="test", min_length=1)
-    run_name: Optional[str] = None
-    tags: Optional[dict[str, str]] = None
+    run_name: str | None = None
+    tags: dict[str, str] | None = None
 
     def create_tl_logger(self) -> MLFlowLogger | None:
         return (
@@ -365,8 +364,8 @@ class MLFlowConfig(BaseModel, YamlLoaderMixin):
 
 
 class ResourceConfig(BaseModel, YamlLoaderMixin):
-    num_cpus: Optional[PositiveInt] = None
-    num_gpus: Optional[NonNegativeInt] = None
+    num_cpus: PositiveInt | None = None
+    num_gpus: NonNegativeInt | None = None
     num_cpus_per_trial: PositiveFloat = 1.0
     num_gpus_per_trial: NonNegativeFloat = 0.25
     gpu_memory_gb: PositiveFloat = (

--- a/stgym/data_loader/__init__.py
+++ b/stgym/data_loader/__init__.py
@@ -155,9 +155,9 @@ def create_loader(
 
 def create_kfold_loader(ds, cfg: DataLoaderConfig):
     """Create data loader with kfold split at fold k."""
-    assert isinstance(
-        cfg.split, DataLoaderConfig.KFoldSplitConfig
-    ), f"Wrong split type {type(cfg.split)}"
+    assert isinstance(cfg.split, DataLoaderConfig.KFoldSplitConfig), (
+        f"Wrong split type {type(cfg.split)}"
+    )
     k = cfg.split.split_index
     # do validation
     DataLoaderConfig.KFoldSplitConfig.model_validate(cfg.split.model_dump())
@@ -210,7 +210,7 @@ class STDataModuleBase(LightningDataModule):
         total = self.ds.x.numel()
         if nan_count > 0:
             raise ValueError(
-                f"Dataset has {nan_count}/{total} ({nan_count/total*100:.1f}%) NaN feature values"
+                f"Dataset has {nan_count}/{total} ({nan_count / total * 100:.1f}%) NaN feature values"
             )
 
     @property

--- a/stgym/data_loader/brca_ptnm_m.py
+++ b/stgym/data_loader/brca_ptnm_m.py
@@ -39,9 +39,9 @@ class BRCAPTNMMDataset(AbstractDataset):
         for name, sample_df in groups:
             # Verify that each sample has only one unique label
             unique_labels = sample_df[LABEL_COL].unique()
-            assert (
-                len(unique_labels) == 1
-            ), f"Sample has inconsistent labels: {unique_labels}"
+            assert len(unique_labels) == 1, (
+                f"Sample has inconsistent labels: {unique_labels}"
+            )
 
             pos = torch.Tensor(sample_df[POS_COLS].values)
             y = torch.tensor(unique_labels[0], dtype=torch.long)

--- a/stgym/data_loader/gastric_bladder_cancer.py
+++ b/stgym/data_loader/gastric_bladder_cancer.py
@@ -58,9 +58,9 @@ class GastricBladderCancerDataset(AbstractDataset):
 
             # Extract label and convert to integer using mapping
             cancer_type = sample_df[LABEL_COL].unique()
-            assert (
-                len(cancer_type) == 1
-            ), f"Sample {sample_id} has multiple labels: {cancer_type}"
+            assert len(cancer_type) == 1, (
+                f"Sample {sample_id} has multiple labels: {cancer_type}"
+            )
 
             cancer_type = cancer_type[0]
             assert cancer_type in LABEL_MAPPING, f"Unknown cancer type: {cancer_type}"
@@ -70,9 +70,9 @@ class GastricBladderCancerDataset(AbstractDataset):
             x = torch.Tensor(sample_df[feature_cols].values)
 
             # Validate data shapes
-            assert (
-                x.shape[0] == pos.shape[0]
-            ), f"Feature and position shape mismatch for {sample_id}"
+            assert x.shape[0] == pos.shape[0], (
+                f"Feature and position shape mismatch for {sample_id}"
+            )
             assert pos.shape[1] == 2, f"Position should be 2D for {sample_id}"
 
             data_list.append(Data(x=x, y=y, pos=pos))

--- a/stgym/data_loader/glioblastoma.py
+++ b/stgym/data_loader/glioblastoma.py
@@ -109,12 +109,12 @@ class GlioblastomaDataset(AbstractDataset):
             x = torch.tensor(feature_data, dtype=torch.float)
 
             # Validate feature matrix
-            assert not torch.isnan(
-                x
-            ).any(), f"NaN values found in features for sample {sample_id}"
-            assert not torch.isinf(
-                x
-            ).any(), f"Infinite values found in features for sample {sample_id}"
+            assert not torch.isnan(x).any(), (
+                f"NaN values found in features for sample {sample_id}"
+            )
+            assert not torch.isinf(x).any(), (
+                f"Infinite values found in features for sample {sample_id}"
+            )
 
             # Create PyTorch Geometric Data object
             data = Data(x=x, y=y, pos=pos)

--- a/stgym/data_loader/human_pancreas.py
+++ b/stgym/data_loader/human_pancreas.py
@@ -69,7 +69,7 @@ class HumanPancreasDataset(AbstractDataset):
                 nan_count = np.isnan(features).sum()
                 total_features = features.shape[0] * features.shape[1]
                 print(
-                    f"Warning: Sample {name} has {nan_count}/{total_features} ({nan_count/total_features*100:.1f}%) NaN feature values"
+                    f"Warning: Sample {name} has {nan_count}/{total_features} ({nan_count / total_features * 100:.1f}%) NaN feature values"
                 )
 
                 # Strategy: Fill NaN with 0 (common for gene expression data)
@@ -79,9 +79,9 @@ class HumanPancreasDataset(AbstractDataset):
             x = torch.Tensor(features)
 
             # Verify dimensions match
-            assert (
-                x.shape[0] == y.shape[0] == pos.shape[0]
-            ), f"Shape mismatch: x={x.shape}, y={y.shape}, pos={pos.shape}"
+            assert x.shape[0] == y.shape[0] == pos.shape[0], (
+                f"Shape mismatch: x={x.shape}, y={y.shape}, pos={pos.shape}"
+            )
 
             # Create PyTorch Geometric Data object
             data_list.append(Data(x=x, y=y, pos=pos))

--- a/stgym/data_loader/mibit.py
+++ b/stgym/data_loader/mibit.py
@@ -43,9 +43,9 @@ class MIBITNBCDataSet(InMemoryDataset):
         super().__init__(root, transform, pre_transform, pre_filter)
         self.load(self.processed_paths[0])
 
-        assert np.isclose(
-            sum(train_val_test_split_ratios), 1.0
-        ), f"{sum(train_val_test_split_ratios)} != 1"
+        assert np.isclose(sum(train_val_test_split_ratios), 1.0), (
+            f"{sum(train_val_test_split_ratios)} != 1"
+        )
 
         np.random.seed(42)
 

--- a/stgym/data_loader/spatial_vdj.py
+++ b/stgym/data_loader/spatial_vdj.py
@@ -94,12 +94,12 @@ class SpatialVDJDataset(AbstractDataset):
             x = torch.tensor(feature_data, dtype=torch.float)
 
             # Validate data shapes
-            assert len(pos) == len(
-                x
-            ), f"Position and feature matrices have different lengths: {len(pos)} vs {len(x)}"
-            assert x.shape[1] == len(
-                FEATURE_COLS
-            ), f"Feature matrix has wrong number of columns: {x.shape[1]} vs {len(FEATURE_COLS)}"
+            assert len(pos) == len(x), (
+                f"Position and feature matrices have different lengths: {len(pos)} vs {len(x)}"
+            )
+            assert x.shape[1] == len(FEATURE_COLS), (
+                f"Feature matrix has wrong number of columns: {x.shape[1]} vs {len(FEATURE_COLS)}"
+            )
 
             # Create graph data object
             data = Data(x=x, y=y, pos=pos)
@@ -116,7 +116,7 @@ class SpatialVDJDataset(AbstractDataset):
         normal_samples = sum(1 for data in data_list if data.y.item() == 0)
         total_spots = sum(data.num_spots for data in data_list)
 
-        print(f"Dataset summary:")
+        print("Dataset summary:")
         print(f"  Cancer samples: {cancer_samples}")
         print(f"  Normal samples: {normal_samples}")
         print(f"  Total spots: {total_spots}")

--- a/stgym/design_space/design_gen.py
+++ b/stgym/design_space/design_gen.py
@@ -50,9 +50,9 @@ def sample_across_dimensions(
 
     if zipped_fields:
         # ensure that the length of the values in zipped fields match
-        assert (
-            len(_.uniq(_.map_(zip_values, len))) == 1
-        ), f"Array length mismatch: {zip_values}"
+        assert len(_.uniq(_.map_(zip_values, len))) == 1, (
+            f"Array length mismatch: {zip_values}"
+        )
 
         sampled_zip_values = random.choice(_.zip_(*zip_values))
         ret = dict(zip(zipped_fields, sampled_zip_values))

--- a/stgym/design_space/schema.py
+++ b/stgym/design_space/schema.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel, PositiveFloat, PositiveInt, field_validator
 
 from stgym.config_schema import (
@@ -16,7 +14,7 @@ from stgym.utils import YamlLoaderMixin
 
 
 class ModelWithZip(BaseModel):
-    zip_: Optional[list[str]] = []  # used to specify the fields to be 'zipped' over
+    zip_: list[str] | None = []  # used to specify the fields to be 'zipped' over
 
 
 class ModelSpace(ModelWithZip):
@@ -27,7 +25,7 @@ class ModelSpace(ModelWithZip):
     num_mp_layers: PositiveInt | list[PositiveInt]
 
     # not null only for graph classification
-    global_pooling: Optional[GlobalPoolingType | list[GlobalPoolingType]] = None
+    global_pooling: GlobalPoolingType | list[GlobalPoolingType] | None = None
 
     normalize_adj: bool | list[bool]
     layer_type: LayerType | list[LayerType]
@@ -38,7 +36,7 @@ class ModelSpace(ModelWithZip):
 
     # temporary hack, which stores a tuple of ints as a comma-separated string
     # because yaml does not distinguish tuple from list
-    post_mp_dims: Optional[str | list[str]] = None
+    post_mp_dims: str | list[str] | None = None
 
 
 class TrainSpace(ModelWithZip):

--- a/stgym/mem_utils.py
+++ b/stgym/mem_utils.py
@@ -15,7 +15,7 @@ Features:
     - Uses cached dataset statistics when available for faster computation
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import torch
 
@@ -123,8 +123,8 @@ def estimate_batch_memory(
     avg_nodes: float,
     avg_edges: float,
     use_max: bool = False,
-    max_nodes: Optional[int] = None,
-    max_edges: Optional[int] = None,
+    max_nodes: int | None = None,
+    max_edges: int | None = None,
 ) -> float:
     """Estimate memory consumption for a single batch in GB.
 
@@ -197,9 +197,9 @@ def get_actual_model_memory(
     model_cfg: GraphClassifierModelConfig | NodeClassifierModelConfig,
     task_cfg: TaskConfig,
     num_features: int,
-    num_classes: Optional[int] = None,
+    num_classes: int | None = None,
     device: str = "cpu",
-) -> Tuple[float, int]:
+) -> tuple[float, int]:
     """Get actual model memory by constructing the model directly.
 
     Args:
@@ -237,7 +237,7 @@ def get_actual_model_memory(
             except RuntimeError as e:
                 if "uninitialized" in str(e).lower():
                     # Skip uninitialized parameters, they don't contribute to memory yet
-                    print(f"Skipping uninitialized parameter")
+                    print("Skipping uninitialized parameter")
                     continue
                 else:
                     raise e
@@ -280,7 +280,7 @@ def estimate_optimizer_memory(model_memory_gb: float, optimizer_type: str) -> fl
 def estimate_memory_usage(
     exp_cfg: ExperimentConfig,
     use_conservative: bool = True,
-) -> Tuple[float, Dict[str, Any]]:
+) -> tuple[float, dict[str, Any]]:
     """Estimate memory needed for experiment (CPU or GPU) with detailed breakdown.
 
     Args:

--- a/stgym/optimizer.py
+++ b/stgym/optimizer.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydash as _
 from torch.nn import Parameter

--- a/stgym/pooling/mincut.py
+++ b/stgym/pooling/mincut.py
@@ -114,7 +114,9 @@ def mincut_pool(
         1e-12 + torch.einsum("ij->i", out_adj).sqrt().to_dense()
     )  # 2nd operand is sparse
     d_norm = torch.sparse_coo_tensor(
-        diagonal_indices, (1 / d), requires_grad=False  # , device=device
+        diagonal_indices,
+        (1 / d),
+        requires_grad=False,  # , device=device
     )
     out_adj_normalized = d_norm @ out_adj @ d_norm
 

--- a/stgym/rct/run.py
+++ b/stgym/rct/run.py
@@ -55,7 +55,7 @@ TL_TRAIN_CFG = {
 def run_exp(
     exp_cfg: ExperimentConfig,
     mlflow_cfg: MLFlowConfig,
-    metadata_for_tag: Optional[dict[str, primitive_type]] = None,
+    metadata_for_tag: dict[str, primitive_type] | None = None,
 ):
     logz_logger.debug(OmegaConf.to_yaml(exp_cfg.model_dump()))
 

--- a/stgym/tl_model.py
+++ b/stgym/tl_model.py
@@ -1,7 +1,7 @@
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import pydash as _
 import pytorch_lightning as pl
@@ -86,7 +86,7 @@ class STGymModule(pl.LightningModule):
     def forward(self, *args, **kwargs):
         return self.model(*args, **kwargs)
 
-    def configure_optimizers(self) -> Tuple[Any, Any]:
+    def configure_optimizers(self) -> tuple[Any, Any]:
         optimizer = create_optimizer_from_cfg(self.train_cfg.optim)(
             self.model.parameters()
         )
@@ -94,7 +94,7 @@ class STGymModule(pl.LightningModule):
         scheduler = create_scheduler(optimizer, self.train_cfg.lr_schedule)
         return [optimizer], [scheduler]
 
-    def _shared_step(self, batch: Data, split: str) -> Dict:
+    def _shared_step(self, batch: Data, split: str) -> dict:
         batch.split = split
 
         if self.task_cfg.type == "graph-classification":

--- a/stgym/train.py
+++ b/stgym/train.py
@@ -15,7 +15,7 @@ def train(
     datamodule: STDataModule | STKfoldDataModule,
     train_cfg: TrainConfig,
     mlflow_config: MLFlowConfig,
-    tl_train_config: Optional[dict[str, any]] = None,
+    tl_train_config: dict[str, any] | None = None,
     logger: Optional = None,
 ):
     r"""Trains a GraphGym model using PyTorch Lightning.

--- a/stgym/transforms.py
+++ b/stgym/transforms.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from torch_geometric.data import Data, HeteroData
 from torch_geometric.transforms import BaseTransform
 
@@ -12,8 +10,8 @@ class AssignSparseCSC(BaseTransform):
 
     def forward(
         self,
-        data: Union[Data, HeteroData],
-    ) -> Union[Data, HeteroData]:
+        data: Data | HeteroData,
+    ) -> Data | HeteroData:
         for store in data.edge_stores:
             if "adj_t" not in store:
                 continue
@@ -29,8 +27,8 @@ class AssignSparseCSR(BaseTransform):
 
     def forward(
         self,
-        data: Union[Data, HeteroData],
-    ) -> Union[Data, HeteroData]:
+        data: Data | HeteroData,
+    ) -> Data | HeteroData:
         for store in data.edge_stores:
             if "adj_t" not in store:
                 continue

--- a/stgym/utils.py
+++ b/stgym/utils.py
@@ -181,7 +181,6 @@ def create_mlflow_experiment(exp_name: str):
 
 
 class YamlLoaderMixin:
-
     @classmethod
     def from_yaml(cls, yaml_file):
         data = load_yaml(yaml_file)

--- a/tests/dataloader/test_brca_grade.py
+++ b/tests/dataloader/test_brca_grade.py
@@ -54,9 +54,9 @@ def test_brca_grade_dataset(mock_df):
     with patch("pandas.read_csv", return_value=mock_df):
         data_root = Path("./tests/data/brca-grade-test")
         ds = BRCAGradeDataset(root=data_root)
-        assert (
-            len(ds) == 3
-        ), f"There should be 3 graph samples (one per grade) but got {len(ds)}"
+        assert len(ds) == 3, (
+            f"There should be 3 graph samples (one per grade) but got {len(ds)}"
+        )
 
         # Test first sample (grade 1 -> label 0)
         data0 = ds[0]

--- a/tests/dataloader/test_glioblastoma.py
+++ b/tests/dataloader/test_glioblastoma.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import patch
 
 import numpy as np
@@ -16,7 +16,7 @@ class TestGlioblastomaDataset:
     """Test GlioblastomaDataset class."""
 
     @property
-    def base_gene_expr_data(self) -> Dict[str, Any]:
+    def base_gene_expr_data(self) -> dict[str, Any]:
         """Base gene expression test data with 3 samples, 2 spots each, 10 genes."""
         gene_names = [f"GENE_{i}" for i in range(10)]
 
@@ -76,7 +76,7 @@ class TestGlioblastomaDataset:
         return data
 
     @property
-    def known_values_data(self) -> Dict[str, Any]:
+    def known_values_data(self) -> dict[str, Any]:
         """Test data with known gene expression values for validation."""
         return {
             "barcode": ["BARCODE001-1", "BARCODE002-1"],
@@ -94,7 +94,7 @@ class TestGlioblastomaDataset:
         }
 
     @property
-    def metadata_filtering_data(self) -> Dict[str, Any]:
+    def metadata_filtering_data(self) -> dict[str, Any]:
         """Test data to verify metadata columns are properly excluded from features."""
         return {
             "barcode": ["BARCODE001-1"],
@@ -110,7 +110,7 @@ class TestGlioblastomaDataset:
         }
 
     @property
-    def inconsistent_labels_data(self) -> Dict[str, Any]:
+    def inconsistent_labels_data(self) -> dict[str, Any]:
         """Test data with inconsistent labels within the same sample (should fail)."""
         return {
             "barcode": ["BARCODE001-1", "BARCODE002-1"],

--- a/tests/dataloader/test_loader.py
+++ b/tests/dataloader/test_loader.py
@@ -49,9 +49,10 @@ def test_create_loader(mock_task_cfg, mock_dl_cfg):
 
 def test_create_kfold_loader(mock_task_cfg, mock_dl_cfg):
     # Use 2 folds for simple validation
-    mock_dl_cfg_0, mock_dl_cfg_1 = mock_dl_cfg.model_copy(
-        deep=True
-    ), mock_dl_cfg.model_copy(deep=True)
+    mock_dl_cfg_0, mock_dl_cfg_1 = (
+        mock_dl_cfg.model_copy(deep=True),
+        mock_dl_cfg.model_copy(deep=True),
+    )
     mock_dl_cfg_0.split = DataLoaderConfig.KFoldSplitConfig(num_folds=2, split_index=0)
     mock_dl_cfg_1.split = DataLoaderConfig.KFoldSplitConfig(num_folds=2, split_index=1)
     dataset = load_dataset(mock_task_cfg, mock_dl_cfg)
@@ -248,9 +249,9 @@ class TestDropLastBehavior:
 
         # Count actual samples to verify expected behavior
         val_samples = sum(len(batch) for batch in val_loader)
-        assert (
-            val_samples == expected_val_samples
-        ), f"Expected {expected_val_samples} validation samples, got {val_samples}"
+        assert val_samples == expected_val_samples, (
+            f"Expected {expected_val_samples} validation samples, got {val_samples}"
+        )
 
         # Verify we can iterate through data (simulates PyTorch Lightning training)
         for batch in val_loader:

--- a/tests/dataloader/test_spatial_vdj.py
+++ b/tests/dataloader/test_spatial_vdj.py
@@ -86,12 +86,12 @@ def test_spatial_vdj_dataset(mock_df):
         cancer_samples = [data for data in ds if data.y.item() == 1]
         normal_samples = [data for data in ds if data.y.item() == 0]
 
-        assert (
-            len(cancer_samples) == 2
-        ), f"Expected 2 cancer samples but got {len(cancer_samples)}"
-        assert (
-            len(normal_samples) == 1
-        ), f"Expected 1 normal sample but got {len(normal_samples)}"
+        assert len(cancer_samples) == 2, (
+            f"Expected 2 cancer samples but got {len(cancer_samples)}"
+        )
+        assert len(normal_samples) == 1, (
+            f"Expected 1 normal sample but got {len(normal_samples)}"
+        )
 
         # Test first cancer sample (P1_RegC2)
         cancer_sample_1 = [data for data in ds if data.sample_id == "P1_RegC2"][0]
@@ -136,9 +136,9 @@ def test_spatial_vdj_dataset(mock_df):
         # Test feature values are reasonable (non-negative)
         for data in ds:
             assert (data.x >= 0).all(), "All feature values should be non-negative"
-            assert (
-                data.x.shape[1] == 16
-            ), f"Each sample should have 16 features, got {data.x.shape[1]}"
+            assert data.x.shape[1] == 16, (
+                f"Each sample should have 16 features, got {data.x.shape[1]}"
+            )
 
         # Clean up test directory
         rm_dir_if_exists(data_root / "processed")

--- a/tests/pooling/dense_dmon.py
+++ b/tests/pooling/dense_dmon.py
@@ -1,5 +1,3 @@
-from typing import Optional, Tuple
-
 import torch
 from torch import Tensor
 from torch_geometric.nn.dense.mincut_pool import _rank3_trace
@@ -10,8 +8,8 @@ EPS = 1e-12
 def dense_dmon_pool(
     s: Tensor,
     adj: Tensor,
-    mask: Optional[Tensor] = None,
-) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+    mask: Tensor | None = None,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
     r"""Forward pass.
 
     Args:

--- a/tests/rct/test_run.py
+++ b/tests/rct/test_run.py
@@ -203,8 +203,9 @@ class TestRunExp:
         """Test that binary classification uses dim_out=1 while multiclass uses num_classes"""
         exp_cfg = self._create_experiment_config(task_key, model_key="graph_clf")
 
-        with patch("stgym.rct.run.STGymModule") as mock_module_class, patch(
-            "stgym.rct.run.train"
+        with (
+            patch("stgym.rct.run.STGymModule") as mock_module_class,
+            patch("stgym.rct.run.train"),
         ):
             mock_module_class.return_value = Mock()
             run_exp(exp_cfg, mlflow_config, metadata_for_tag=self.metadata_for_tag)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -191,9 +191,9 @@ def test_data_stays_on_cpu_and_lightning_transfers_to_device(
 
     # 1. Verify dataset stays on CPU after construction
     for data in data_module.ds:
-        assert data.x.device == torch.device(
-            "cpu"
-        ), f"Dataset should stay on CPU, but found {data.x.device}"
+        assert data.x.device == torch.device("cpu"), (
+            f"Dataset should stay on CPU, but found {data.x.device}"
+        )
         break  # checking one sample is sufficient
 
     # 2. Verify batches arrive on the expected device during training
@@ -221,8 +221,8 @@ def test_data_stays_on_cpu_and_lightning_transfers_to_device(
     assert len(observed_devices) > 0, "training_step was never called"
     expected_type = torch.device(TORCH_DEVICE).type
     for dev in observed_devices:
-        assert (
-            dev.type == expected_type
-        ), f"Batch should be on {expected_type}, but found {dev}"
+        assert dev.type == expected_type, (
+            f"Batch should be on {expected_type}, but found {dev}"
+        )
 
     rm_dir_if_exists("tests/data/brca-test/processed")

--- a/uv.lock
+++ b/uv.lock
@@ -175,15 +175,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astroid"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -199,50 +190,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
-name = "autopep8"
-version = "2.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycodestyle" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
-]
-
-[[package]]
-name = "black"
-version = "26.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
-    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
-    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
-    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
-    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
-    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
-    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -623,15 +570,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -686,20 +624,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
 ]
 
 [[package]]
@@ -1172,15 +1096,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
-]
-
-[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1365,66 +1280,6 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
-    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
-    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
-    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
-    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
-    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
-    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
-    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
-    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
-    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
-    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
-    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
-]
-
-[[package]]
 name = "lightning-utilities"
 version = "0.15.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1588,15 +1443,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1831,48 +1677,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
-    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
-    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
-    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
-    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
-    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2088,15 +1892,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -2448,15 +2243,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2564,15 +2350,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
-]
-
-[[package]]
 name = "pyg-lib"
 version = "0.4.0+pt27cpu"
 source = { registry = "https://data.pyg.org/whl/torch-2.7.0+cpu.html" }
@@ -2588,24 +2365,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pylint"
-version = "4.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
 ]
 
 [[package]]
@@ -2665,35 +2424,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -2962,6 +2692,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
 
 [[package]]
@@ -3236,15 +2991,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "autopep8" },
-    { name = "black" },
-    { name = "flake8" },
-    { name = "isort" },
-    { name = "mypy" },
     { name = "pre-commit" },
-    { name = "pylint" },
     { name = "pytest" },
-    { name = "yapf" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -3281,15 +3031,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "autopep8" },
-    { name = "black" },
-    { name = "flake8" },
-    { name = "isort" },
-    { name = "mypy" },
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pylint" },
     { name = "pytest" },
-    { name = "yapf" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [[package]]
@@ -3320,15 +3065,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]
@@ -3586,6 +3322,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/96/652a425030f95dc2c9548d9019e52502e17079e1daeefbc4036f1c0905b4/ty-0.0.24.tar.gz", hash = "sha256:9fe42f6b98207bdaef51f71487d6d087f2cb02555ee3939884d779b2b3cc8bfc", size = 5354286, upload-time = "2026-03-19T16:55:57.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/e5/34457ee11708e734ba81ad65723af83030e484f961e281d57d1eecf08951/ty-0.0.24-py3-none-linux_armv6l.whl", hash = "sha256:1ab4f1f61334d533a3fdf5d9772b51b1300ac5da4f3cdb0be9657a3ccb2ce3e7", size = 10394877, upload-time = "2026-03-19T16:55:54.246Z" },
+    { url = "https://files.pythonhosted.org/packages/44/81/bc9a1b1a87f43db15ab64ad781a4f999734ec3b470ad042624fa875b20e6/ty-0.0.24-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:facbf2c4aaa6985229e08f8f9bf152215eb078212f22b5c2411f35386688ab42", size = 10211109, upload-time = "2026-03-19T16:55:28.554Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/cfc805adeaa61d63ba3ea71127efa7d97c40ba36d97ee7bd957341d05107/ty-0.0.24-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b6d2a3b6d4470c483552a31e9b368c86f154dcc964bccb5406159dc9cd362246", size = 9694769, upload-time = "2026-03-19T16:55:34.309Z" },
+    { url = "https://files.pythonhosted.org/packages/33/09/edc220726b6ec44a58900401f6b27140997ef15026b791e26b69a6e69eb5/ty-0.0.24-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c94c25d0500939fd5f8f16ce41cbed5b20528702c1d649bf80300253813f0a2", size = 10176287, upload-time = "2026-03-19T16:55:37.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/bf/cbe2227be711e65017655d8ee4d050f4c92b113fb4dc4c3bd6a19d3a86d8/ty-0.0.24-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:89cbe7bc7df0fab02dbd8cda79b737df83f1ef7fb573b08c0ee043dc68cffb08", size = 10214832, upload-time = "2026-03-19T16:56:08.518Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1d/d15803ee47e9143d10e10bd81ccc14761d08758082bda402950685f0ddfe/ty-0.0.24-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db2c5d269bcc9b764850c99f457b5018a79b3ef40ecfbc03344e65effd6cf743", size = 10709892, upload-time = "2026-03-19T16:56:05.727Z" },
+    { url = "https://files.pythonhosted.org/packages/36/12/6db0d86c477147f67b9052de209421d76c3e855197b000c25fcbbe86b3a2/ty-0.0.24-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba44512db5b97c3bbd59d93e11296e8548d0c9a3bdd1280de36d7ff22d351896", size = 11280872, upload-time = "2026-03-19T16:56:02.899Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fc/155fe83a97c06d33ccc9e0f428258b32df2e08a428300c715d34757f0111/ty-0.0.24-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a52b7f589c3205512a9c50ba5b2b1e8c0698b72e51b8b9285c90420c06f1cae8", size = 11060520, upload-time = "2026-03-19T16:55:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f1/32c05a1c4c3c2a95c5b7361dee03a9bf1231d4ad096b161c838b45bce5a0/ty-0.0.24-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7981df5c709c054da4ac5d7c93f8feb8f45e69e829e4461df4d5f0988fe67d04", size = 10791455, upload-time = "2026-03-19T16:55:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2c/53c1ea6bedfa4d4ab64d4de262d8f5e405ecbffefd364459c628c0310d33/ty-0.0.24-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b2860151ad95a00d0f0280b8fef79900d08dcd63276b57e6e5774f2c055979c5", size = 10156708, upload-time = "2026-03-19T16:55:45.563Z" },
+    { url = "https://files.pythonhosted.org/packages/45/39/7d2919cf194707169474d80720a5f3d793e983416f25e7ffcf80504c9df2/ty-0.0.24-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5674a1146d927ab77ff198a88e0c4505134ced342a0e7d1beb4a076a728b7496", size = 10236263, upload-time = "2026-03-19T16:55:31.474Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7f/48eac722f2fd12a5b7aae0effdcb75c46053f94b783d989e3ef0d7380082/ty-0.0.24-py3-none-musllinux_1_2_i686.whl", hash = "sha256:438ecbf1608a9b16dd84502f3f1b23ef2ef32bbd0ab3e0ca5a82f0e0d1cd41ea", size = 10402559, upload-time = "2026-03-19T16:55:39.602Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e0/8cf868b9749ce1e5166462759545964e95b02353243594062b927d8bff2a/ty-0.0.24-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ddeed3098dd92a83964e7aa7b41e509ba3530eb539fc4cd8322ff64a09daf1f5", size = 10893684, upload-time = "2026-03-19T16:55:51.439Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9f/f54bf3be01d2c2ed731d10a5afa3324dc66f987a6ae0a4a6cbfa2323d080/ty-0.0.24-py3-none-win32.whl", hash = "sha256:83013fb3a4764a8f8bcc6ca11ff8bdfd8c5f719fc249241cb2b8916e80778eb1", size = 9781542, upload-time = "2026-03-19T16:56:11.588Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/49/c004c5cc258b10b3a145666e9a9c28ae7678bc958c8926e8078d5d769081/ty-0.0.24-py3-none-win_amd64.whl", hash = "sha256:748a60eb6912d1cf27aaab105ffadb6f4d2e458a3fcadfbd3cf26db0d8062eeb", size = 10764801, upload-time = "2026-03-19T16:55:42.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/006a074e185bfccf5e4c026015245ab4fcd2362b13a8d24cf37a277909a9/ty-0.0.24-py3-none-win_arm64.whl", hash = "sha256:280a3d31e86d0721947238f17030c33f0911cae851d108ea9f4e3ab12a5ed01f", size = 10194093, upload-time = "2026-03-19T16:55:48.303Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3763,18 +3523,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
     { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
     { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
-]
-
-[[package]]
-name = "yapf"
-version = "0.43.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/97/b6f296d1e9cc1ec25c7604178b48532fa5901f721bcf1b8d8148b13e5588/yapf-0.43.0.tar.gz", hash = "sha256:00d3aa24bfedff9420b2e0d5d9f5ab6d9d4268e72afbf59bb3fa542781d5218e", size = 254907, upload-time = "2024-11-14T00:11:41.584Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/81/6acd6601f61e31cfb8729d3da6d5df966f80f374b78eff83760714487338/yapf-0.43.0-py3-none-any.whl", hash = "sha256:224faffbc39c428cb095818cf6ef5511fdab6f7430a10783fdfb292ccf2852ca", size = 256158, upload-time = "2024-11-14T00:11:39.37Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `black`, `isort`, `flake8`, `pylint`, `mypy`, `autopep8`, `yapf` with `ruff` and `ty` in dev dependency group
- Add `[tool.ruff]` config (line-length=88, target py312) with E/F/I/UP rule sets covering pycodestyle, pyflakes, import sorting, and pyupgrade
- Update `.pre-commit-config.yaml`: remove autoflake/black/isort/pyupgrade/nbQA hooks; add local `ruff`, `ruff-format`, and `ty` hooks via `uv run` (all advisory with `--exit-zero` so existing violations don't block commits)
- Apply ruff formatting and import fixes across the codebase

## Test plan

- [x] `uv sync --group dev` installs `ruff` and `ty` successfully
- [x] Pre-commit hooks (`ruff`, `ruff-format`, `ty`) run without blocking commits on existing code

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)