### PR TITLE
feat: sweep progress tracker by design dimension

### DIFF
--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -283,7 +283,7 @@ def main():
     if args.max_results > 0 and len(runs) == args.max_results:
         print(
             f"WARNING: results may be truncated at {args.max_results} runs. "
-            "Use --max-results 0 to fetch all."
+            "Increase --max-results to fetch more."
         )
 
     dim_stats = classify_dims(runs, args.stale_threshold)


### PR DESCRIPTION
## Summary

Closes #100

Adds `scripts/sweep_status.py` — queries an MLflow experiment and prints a structured per-design-dimension progress summary grouped into DONE, IN PROGRESS, and PENDING sections.

## Usage

```bash
# by experiment ID
python scripts/sweep_status.py -i 203473023442981332

# by experiment name
python scripts/sweep_status.py -n sweep-all-20260323

# limit fetched runs (for debugging)
python scripts/sweep_status.py -i <id> --max-results 200
```

Run from the project root so `--conf-dir conf/exp` (default) resolves correctly.

## Output

```
Fetched 2400 runs from 'sweep-all-20260323-212509'.

Experiment : sweep-all-20260323-212509
ID         : 203473023442981332
Sample size: 100 groups/dimension
Dimensions : 10 done, 1 in progress, 2 pending

================================================================================
DONE
================================================================================
       dimension      task              choices  finished  failed  stale  avg_min  total_min
       model.act  graph-clf  prelu|relu|swish       280      20      0      4.4     1320.0
             ...

================================================================================
IN PROGRESS
================================================================================
  dimension      task         choices  done  total  active  failed  stale
  data_loader.batch_size  both  4|8|16|32    60    400      6       4      2

================================================================================
PENDING
================================================================================
              dimension               choices  total
  model.pooling.n_clusters         5|10|20|30    400
```

## Options

| Flag | Default | Description |
|------|---------|-------------|
| `-i` / `--experiment-id` | — | Target experiment ID (mutually exclusive with `-n`) |
| `-n` / `--experiment-name` | — | Target experiment name (mutually exclusive with `-i`) |
| `--tracking-uri` | `http://127.0.0.1:5001` | MLflow server |
| `--sample-size` | `100` | Number of groups per dimension |
| `--stale-threshold` | `20` (min) | Age before a RUNNING run is treated as a zombie (see PR #99) |
| `--conf-dir` | `conf/exp` | Directory of exp YAML configs for PENDING inference |
| `--max-results` | `5000` | Max runs to fetch; warns if result hits this limit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)