### PR TITLE
feat(sweep-status): add experiment-level statistics and per-dim time span

### DIFF
--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -239,7 +239,7 @@ def print_summary(
 
     if exp_stats:
         start_dt = datetime.datetime.fromtimestamp(
-            exp_stats["exp_start_ms"] / 1000, tz=datetime.timezone.utc
+            exp_stats["exp_start_ms"] / 1000, tz=datetime.UTC
         ).strftime("%Y-%m-%d %H:%M UTC")
         print(
             f"\nExp duration: {exp_stats['exp_duration_h']:.1f} h  (started {start_dt})"


### PR DESCRIPTION
## Summary

Extends `scripts/sweep_status.py` with experiment-level statistics and fixes several correctness issues.

## New experiment-level header

```
Exp duration: 14.3 h  (started 2026-03-23 12:05 UTC)
Finished    : 1820 ok  /  180 failed
Throughput  : ~127.3 runs/h

Completed last  2 h :   107
Completed last 12 h :   640
Completed last 24 h : 1120
```

## Per-dimension table changes

| Column | Description |
|--------|-------------|
| `trials` | Expected logical trials = `sample_size × num_choices` (one k-fold CV job = 1 trial) |
| `total_runs` | Total raw MLflow runs fetched (finished + failed + active + stale) |
| `time_span_min` | Wall-clock span from first run start to last run end |
| `cumul_min` | Sum of individual finished run durations |

## State simplification

Replaced the fragile DONE / IN PROGRESS classification (which could flip during worker lulls) with two simple states:

- **STARTED** — dimension has at least one run in MLflow
- **PENDING** — dimension exists in `conf/exp/` but no runs yet

## Bug fixes

- **Clock skew**: `now_ms` is now derived from the latest MLflow server timestamp instead of `time.time()` on the local machine, avoiding drift between the local environment (Finland) and the GPU server (China)
- **DeprecationWarning**: replaced `datetime.utcfromtimestamp()` with timezone-aware `datetime.fromtimestamp(..., tz=datetime.timezone.utc)`
- **`trials` vs `total`**: previous `total = sample_size × num_choices` was mislabelled — renamed to `trials` to make clear it counts logical experiment units, not raw MLflow runs

## Implementation

- New `compute_exp_stats(runs, now_ms)` — experiment-level timing and throughput
- `classify_dims` — accepts `now_ms` as parameter; tracks `min_start_ms`/`max_end_ms` per dimension for `time_span_min`
- `build_sweep_status_df` — single STARTED table replacing the old DONE/IN PROGRESS split

🤖 Generated with [Claude Code](https://claude.com/claude-code)