### PR TITLE
fix: detach loss and true tensors in step outputs (#107)

### DIFF
--- a/stgym/rct/run.py
+++ b/stgym/rct/run.py
@@ -46,9 +46,9 @@ def get_dim_out(task_cfg: TaskConfig) -> int | None:
 TL_TRAIN_CFG = {
     "log_every_n_steps": 5,
     # simplify the logging
-    "enable_progress_bar": True,
+    # "enable_progress_bar": True,
     # "enable_model_summary": True,
-    # "enable_progress_bar": False,
+    "enable_progress_bar": False,
     "enable_model_summary": False,
     "enable_checkpointing": False,
 }


### PR DESCRIPTION
## Summary

- Detach `loss` and `true` before storing in `val_step_outputs` / `test_step_outputs` in `_shared_step` (both graph-classification and node-classification paths)
- Remove stale commented-out memory recording code from `run_experiment_by_yaml.py`

## Investigation notes

The concern (from #107) was that undetached tensors would accumulate the full computation graph across validation batches. Investigation showed this doesn't occur in practice — PyTorch Lightning wraps `validation_step` in `torch.no_grad()`, so `loss.grad_fn` is `None` and no graph is retained. Process RSS was stable across epochs with no monotonic growth.

The `.detach()` calls are applied as defensive practice: makes intent explicit and guards against any future use of `_shared_step` outside PL's managed validation loop.

See full findings: https://github.com/xiaohan2012/stgym/issues/107#issuecomment-4137557058

## Test plan

- [ ] `pytest tests/ -m 'not slow'`
- [ ] Quick GPU test: `bash scripts/test_on_gpu.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)