### PR TITLE
feat: budget and observability for autonomous agents (#150)

### DIFF
--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -22,26 +22,7 @@ source .venv/bin/activate
 
 ## Labeling Scheme
 
-Every triaged issue must have exactly ONE status label, ONE type label, and ONE priority label. See CLAUDE.md for the full scheme.
-
-### Status (mutually exclusive, prefix `status/`)
-
-| Label | Meaning |
-|---|---|
-| `status/new` | Just created, not yet triaged |
-| `status/triaged` | PM reviewed, priority/type assigned |
-| `status/ready` | All blockers resolved, can be picked up |
-| `status/in-progress` | Developer working on it |
-| `status/needs-review` | PR opened, awaiting reviewer |
-| `status/done` | Merged and closed |
-
-### Type (mutually exclusive)
-
-`bug`, `enhancement`, `optimization`, `refactor`, `docs`, `infra`
-
-### Priority
-
-`P0` (critical) > `P1` (high) > `P2` (normal) > `P3` (low)
+Every triaged issue must have exactly ONE status label, ONE type label, and ONE priority label. See CLAUDE.md → **Labeling Scheme** (auto-loaded) for the canonical list of labels, types, and priorities.
 
 ## Core Workflows
 

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ mlruns
 
 # Agent activity log (local, shared by all agents)
 ACTIVITY.log
+
+# OpenTelemetry logs from the sandbox — may contain bash commands with
+# inlined env vars; never commit.
+sandbox/telemetry/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,4 +230,7 @@ Each agent's prompt already includes the append-on-start/finish rule; this secti
 | Code changes | Git branches + PRs |
 | Review feedback | GitHub PR review comments |
 | Agent activity log | `ACTIVITY.log` (gitignored, repo root) |
+| Agent cost / token telemetry | `sandbox/telemetry/otel-*.jsonl` (gitignored) — see `sandbox/README.md` |
 | Project conventions | `CLAUDE.md` (this file) |
+
+For sandbox usage, agent turn caps, telemetry setup, and the weekly cost review workflow, see `sandbox/README.md`.

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -28,7 +28,21 @@ If an agent consistently hits its cap, that's a signal to look at the telemetry 
 
 ### Telemetry (OpenTelemetry)
 
-The sandbox enables Claude Code's OTel output via env vars in `sandbox/docker-compose.yml`. Events (metrics + per-turn records) are written via the console exporter to `/var/log/claude-telemetry/otel-<timestamp>.jsonl` inside the container, which is bind-mounted to `sandbox/telemetry/` on the host. `sandbox/claude.sh` generates a fresh log file per invocation and runs output through a secret-scrubbing `sed` filter on the way in.
+The sandbox runs a second service alongside the agent: an **OpenTelemetry Collector** sidecar (`otel/opentelemetry-collector-contrib`). The agent emits OTel metrics + logs over OTLP/gRPC to `otel-collector:4317`; the collector batches them and writes newline-delimited JSON to `/var/log/claude-telemetry/otel.jsonl`, which is bind-mounted to `sandbox/telemetry/` on the host. Rotation (50 MB per file, 10 backups, 30 days) is configured in `sandbox/otel-collector-config.yaml`.
+
+Architecture:
+
+```
+┌─────────┐   OTLP/gRPC    ┌────────────────┐   file        ┌──────────────────┐
+│  agent  │ ─────────────> │ otel-collector │ ────────────> │ sandbox/telemetry│
+│ (claude)│   :4317        │    sidecar     │  (JSONL +     │  /otel.jsonl*    │
+└─────────┘                └────────────────┘   rotation)   └──────────────────┘
+                                                                    ▲
+                                                                    │ host bind mount
+                                                         scripts/cost-report.sh
+```
+
+Why a collector instead of the console exporter: Claude Code's console exporter writes a multi-line pretty-printed JS object to stdout, which is not trivially parseable. OTLP → collector → file exporter gives us clean single-line JSON that `jq` can consume.
 
 **What's logged (`OTEL_LOG_TOOL_DETAILS=1`, `OTEL_LOG_USER_PROMPTS=1`):**
 - Per-turn cost, tokens (input/output/cache), duration, model
@@ -57,10 +71,10 @@ For ad-hoc spot-checks inside an interactive session, use the `/cost` slash comm
 
 ### Security: never share telemetry files
 
-`sandbox/telemetry/` is gitignored — do not commit, paste, or attach these files anywhere public. Even with the scrub filter, the logs contain:
+`sandbox/telemetry/` is gitignored — do not commit, paste, or attach these files anywhere public. The raw files contain:
 
 - Bash commands the agent ran (may include env-var expansions)
 - File paths and GitHub URLs touched during work
 - Your prompt text
 
-The scrub filter redacts common secret patterns (`ghp_*`, `sk-ant-*`, `AKIA*`, private keys, etc.) but it's not exhaustive. Before sharing any output from `sandbox/telemetry/` (e.g. in a bug report), `grep` for `REDACTED` to confirm the scrubber ran, and give the file a manual skim.
+**Important:** the collector writes raw OTLP data without any scrubbing — `otel.jsonl` may contain unredacted secrets if an agent ever inlined one into a command. Scrubbing happens at **read time** inside `scripts/cost-report.sh` via a `sed` pipeline that matches common patterns (`ghp_*`, `sk-ant-*`, `sk-*`, `AKIA*`, `xox[baprs]-*`, private keys). Before sharing any excerpt from `sandbox/telemetry/` (e.g. in a bug report), run it through the report script and `grep` for `REDACTED` to confirm the scrubber fired, and still give the output a manual skim.

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,66 @@
+# Sandbox
+
+Docker sandbox for running Claude Code agents (PM / Developer / Reviewer) in an isolated environment with auto-accepted permissions.
+
+## Usage
+
+```bash
+bash sandbox/run.sh       # build + enter interactive shell in the container
+bash sandbox/claude.sh    # start Claude Code inside the sandbox (interactive)
+bash sandbox/claude.sh "take issue #150 and implement it"   # one-shot
+```
+
+`run.sh` extracts the Claude Code OAuth refresh token from the macOS Keychain and `GH_TOKEN` from `gh auth token`, then starts the container with the repo bind-mounted at `/repo`.
+
+## Cost & Observability
+
+Autonomous agents can burn tokens silently — loops, wasted re-reads, runaway retries. Two safeguards: **turn caps** to bound a single run, and **telemetry** to review spend after the fact.
+
+### Turn caps (`maxTurns`)
+
+Set in each agent's frontmatter to bound a single invocation:
+
+- **PM** — 30 (triage is cheap; if it's hitting 30 something is stuck)
+- **Developer** — 100 (implementation + tests + review + PR)
+- **Reviewer** — 50 (read diff, check, comment)
+
+If an agent consistently hits its cap, that's a signal to look at the telemetry for that session and either fix the prompt or raise the cap deliberately.
+
+### Telemetry (OpenTelemetry)
+
+The sandbox enables Claude Code's OTel output via env vars in `sandbox/docker-compose.yml`. Events (metrics + per-turn records) are written via the console exporter to `/var/log/claude-telemetry/otel-<timestamp>.jsonl` inside the container, which is bind-mounted to `sandbox/telemetry/` on the host. `sandbox/claude.sh` generates a fresh log file per invocation and runs output through a secret-scrubbing `sed` filter on the way in.
+
+**What's logged (`OTEL_LOG_TOOL_DETAILS=1`, `OTEL_LOG_USER_PROMPTS=1`):**
+- Per-turn cost, tokens (input/output/cache), duration, model
+- Tool calls: tool name, inputs (bash command, file path, URL), duration, success/failure
+- User prompts (text)
+- API errors, retries, rate limits
+
+**What's NOT logged:**
+- Tool outputs (file contents, command stdout/stderr, response bodies) — `OTEL_LOG_TOOL_CONTENT` is intentionally off
+- Model responses
+
+### Weekly review
+
+```bash
+bash scripts/cost-report.sh          # last 7 days
+bash scripts/cost-report.sh 30       # last 30 days
+```
+
+Prints per-session totals (turns, cost, tokens, error count, first prompt) sorted by cost, plus grand totals. Look for:
+
+- Sessions near the `maxTurns` ceiling → agent is stuck or prompt is vague
+- Input tokens trending up session-over-session → context bloat
+- `api_error` count > 0 → rate limits or model errors worth checking
+
+For ad-hoc spot-checks inside an interactive session, use the `/cost` slash command.
+
+### Security: never share telemetry files
+
+`sandbox/telemetry/` is gitignored — do not commit, paste, or attach these files anywhere public. Even with the scrub filter, the logs contain:
+
+- Bash commands the agent ran (may include env-var expansions)
+- File paths and GitHub URLs touched during work
+- Your prompt text
+
+The scrub filter redacts common secret patterns (`ghp_*`, `sk-ant-*`, `AKIA*`, private keys, etc.) but it's not exhaustive. Before sharing any output from `sandbox/telemetry/` (e.g. in a bug report), `grep` for `REDACTED` to confirm the scrubber ran, and give the file a manual skim.

--- a/sandbox/claude.sh
+++ b/sandbox/claude.sh
@@ -1,44 +1,17 @@
 #!/bin/bash
 # Start Claude Code in the sandbox with all permissions auto-accepted.
-# Captures OpenTelemetry output (metrics + events) to a per-invocation JSONL
-# file under /var/log/claude-telemetry (bind-mounted to sandbox/telemetry/
-# on the host).
+#
+# Telemetry capture is handled out-of-band by the otel-collector sidecar
+# (see sandbox/docker-compose.yml and sandbox/otel-collector-config.yaml).
+# No stdio wrapping needed here.
 #
 # Usage: bash sandbox/claude.sh "your prompt here"
 #   or:  bash sandbox/claude.sh   (interactive mode)
 
 set -euo pipefail
 
-TELEMETRY_DIR=/var/log/claude-telemetry
-LOG_FILE="$TELEMETRY_DIR/otel-$(date -u +'%Y%m%dT%H%M%SZ').jsonl"
-
-mkdir -p "$TELEMETRY_DIR"
-
-# Inline secret scrub: redact known secret patterns before they hit disk.
-# Applied to every telemetry line. Belt-and-braces vs. an agent ever
-# inlining an env var into a bash command / prompt. Patterns cover common
-# token formats; extend as new ones appear.
-scrub() {
-    sed -E \
-        -e 's/ghp_[A-Za-z0-9]{20,}/[REDACTED:ghp]/g' \
-        -e 's/gho_[A-Za-z0-9]{20,}/[REDACTED:gho]/g' \
-        -e 's/ghu_[A-Za-z0-9]{20,}/[REDACTED:ghu]/g' \
-        -e 's/ghs_[A-Za-z0-9]{20,}/[REDACTED:ghs]/g' \
-        -e 's/ghr_[A-Za-z0-9]{20,}/[REDACTED:ghr]/g' \
-        -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED:anthropic]/g' \
-        -e 's/sk-[A-Za-z0-9]{32,}/[REDACTED:openai]/g' \
-        -e 's/-----BEGIN [A-Z ]*PRIVATE KEY-----/[REDACTED:private-key]/g' \
-        -e 's/xox[baprs]-[A-Za-z0-9-]{10,}/[REDACTED:slack]/g' \
-        -e 's/AKIA[0-9A-Z]{16}/[REDACTED:aws-access-key]/g'
-}
-
-# Claude Code writes telemetry to stderr via the console exporter. Fork
-# stderr through the scrub filter into the log file while preserving
-# terminal visibility.
 if [ $# -gt 0 ]; then
-    claude -p --dangerously-skip-permissions "$@" \
-        2> >(scrub | tee -a "$LOG_FILE" >&2)
+    claude -p --dangerously-skip-permissions "$@"
 else
-    claude --dangerously-skip-permissions \
-        2> >(scrub | tee -a "$LOG_FILE" >&2)
+    claude --dangerously-skip-permissions
 fi

--- a/sandbox/claude.sh
+++ b/sandbox/claude.sh
@@ -1,12 +1,44 @@
 #!/bin/bash
 # Start Claude Code in the sandbox with all permissions auto-accepted.
+# Captures OpenTelemetry output (metrics + events) to a per-invocation JSONL
+# file under /var/log/claude-telemetry (bind-mounted to sandbox/telemetry/
+# on the host).
+#
 # Usage: bash sandbox/claude.sh "your prompt here"
 #   or:  bash sandbox/claude.sh   (interactive mode)
 
 set -euo pipefail
 
+TELEMETRY_DIR=/var/log/claude-telemetry
+LOG_FILE="$TELEMETRY_DIR/otel-$(date -u +'%Y%m%dT%H%M%SZ').jsonl"
+
+mkdir -p "$TELEMETRY_DIR"
+
+# Inline secret scrub: redact known secret patterns before they hit disk.
+# Applied to every telemetry line. Belt-and-braces vs. an agent ever
+# inlining an env var into a bash command / prompt. Patterns cover common
+# token formats; extend as new ones appear.
+scrub() {
+    sed -E \
+        -e 's/ghp_[A-Za-z0-9]{20,}/[REDACTED:ghp]/g' \
+        -e 's/gho_[A-Za-z0-9]{20,}/[REDACTED:gho]/g' \
+        -e 's/ghu_[A-Za-z0-9]{20,}/[REDACTED:ghu]/g' \
+        -e 's/ghs_[A-Za-z0-9]{20,}/[REDACTED:ghs]/g' \
+        -e 's/ghr_[A-Za-z0-9]{20,}/[REDACTED:ghr]/g' \
+        -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED:anthropic]/g' \
+        -e 's/sk-[A-Za-z0-9]{32,}/[REDACTED:openai]/g' \
+        -e 's/-----BEGIN [A-Z ]*PRIVATE KEY-----/[REDACTED:private-key]/g' \
+        -e 's/xox[baprs]-[A-Za-z0-9-]{10,}/[REDACTED:slack]/g' \
+        -e 's/AKIA[0-9A-Z]{16}/[REDACTED:aws-access-key]/g'
+}
+
+# Claude Code writes telemetry to stderr via the console exporter. Fork
+# stderr through the scrub filter into the log file while preserving
+# terminal visibility.
 if [ $# -gt 0 ]; then
-    claude -p --dangerously-skip-permissions "$@"
+    claude -p --dangerously-skip-permissions "$@" \
+        2> >(scrub | tee -a "$LOG_FILE" >&2)
 else
-    claude --dangerously-skip-permissions
+    claude --dangerously-skip-permissions \
+        2> >(scrub | tee -a "$LOG_FILE" >&2)
 fi

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.113.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+      # Shared bind mount with the host — cost-report.sh reads from here.
+      - ./telemetry:/var/log/claude-telemetry
+    restart: unless-stopped
+
   agent:
     build:
       context: .
@@ -7,23 +16,23 @@ services:
       - ..:/repo
       - ~/.ssh:/home/agent/.ssh:ro
       - uv-cache:/home/agent/.cache/uv
-      # Telemetry logs bind-mounted to host so they're readable without
-      # entering the container. Kept outside /repo so the agent can't grep
-      # its own past telemetry and leak prior-session context.
-      - ./telemetry:/var/log/claude-telemetry
     environment:
       - GH_TOKEN
       - CLAUDE_CODE_OAUTH_REFRESH_TOKEN
       - CLAUDE_CODE_OAUTH_SCOPES=user:profile user:inference user:sessions:claude_code
-      # OpenTelemetry — see CLAUDE.md § Cost & Observability
+      # OpenTelemetry — see sandbox/README.md § Cost & Observability
       - CLAUDE_CODE_ENABLE_TELEMETRY=1
-      - OTEL_METRICS_EXPORTER=console
-      - OTEL_LOGS_EXPORTER=console
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_METRIC_EXPORT_INTERVAL=60000
       - OTEL_LOG_TOOL_DETAILS=1
       - OTEL_LOG_USER_PROMPTS=1
       # Intentionally NOT set: OTEL_LOG_TOOL_CONTENT (would log file
       # contents + command output — too much surface area).
+    depends_on:
+      - otel-collector
     working_dir: /repo
     command: []
     stdin_open: true

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -7,10 +7,23 @@ services:
       - ..:/repo
       - ~/.ssh:/home/agent/.ssh:ro
       - uv-cache:/home/agent/.cache/uv
+      # Telemetry logs bind-mounted to host so they're readable without
+      # entering the container. Kept outside /repo so the agent can't grep
+      # its own past telemetry and leak prior-session context.
+      - ./telemetry:/var/log/claude-telemetry
     environment:
       - GH_TOKEN
       - CLAUDE_CODE_OAUTH_REFRESH_TOKEN
       - CLAUDE_CODE_OAUTH_SCOPES=user:profile user:inference user:sessions:claude_code
+      # OpenTelemetry — see CLAUDE.md § Cost & Observability
+      - CLAUDE_CODE_ENABLE_TELEMETRY=1
+      - OTEL_METRICS_EXPORTER=console
+      - OTEL_LOGS_EXPORTER=console
+      - OTEL_METRIC_EXPORT_INTERVAL=60000
+      - OTEL_LOG_TOOL_DETAILS=1
+      - OTEL_LOG_USER_PROMPTS=1
+      # Intentionally NOT set: OTEL_LOG_TOOL_CONTENT (would log file
+      # contents + command output — too much surface area).
     working_dir: /repo
     command: []
     stdin_open: true

--- a/sandbox/otel-collector-config.yaml
+++ b/sandbox/otel-collector-config.yaml
@@ -1,0 +1,43 @@
+# OpenTelemetry Collector config for the sandbox.
+#
+# Receives OTLP telemetry from the Claude Code agent (gRPC on :4317,
+# HTTP on :4318) and writes it as JSONL to a host-visible file via the
+# built-in file exporter. See sandbox/README.md § Cost & Observability.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    # Flush small batches quickly so per-session data shows up in the
+    # log file without long delays during debugging.
+    timeout: 5s
+    send_batch_size: 100
+
+exporters:
+  file:
+    path: /var/log/claude-telemetry/otel.jsonl
+    rotation:
+      max_megabytes: 50
+      max_days: 30
+      max_backups: 10
+    format: json
+
+service:
+  telemetry:
+    logs:
+      level: warn
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file]

--- a/sandbox/run.sh
+++ b/sandbox/run.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Ensure the host-side telemetry dir exists before docker compose mounts it.
+# Otherwise Docker creates it as root on Linux (ownership headaches).
+mkdir -p "$SCRIPT_DIR/telemetry"
+
 # Extract Claude Code OAuth refresh token from macOS Keychain
 export CLAUDE_CODE_OAUTH_REFRESH_TOKEN=$(
   security find-generic-password -s "Claude Code-credentials" -w \

--- a/scripts/cost-report.sh
+++ b/scripts/cost-report.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Weekly cost & observability summary over sandbox telemetry logs.
 #
-# Reads sandbox/telemetry/otel-*.jsonl (produced by sandbox/claude.sh)
-# and prints per-session totals: turn count, cost, tokens, first user
-# prompt. Used for the weekly cost review — see CLAUDE.md § Cost &
-# Observability.
+# Reads sandbox/telemetry/otel.jsonl* (produced by the OTel collector
+# sidecar in sandbox/docker-compose.yml) and prints per-session totals:
+# turn count, cost, tokens, first user prompt.
+#
+# Pipeline: JSONL → secret scrub → flatten OTLP envelopes → jq aggregation.
+# See sandbox/README.md § Cost & Observability.
 #
 # Usage: bash scripts/cost-report.sh [days]
 #   days defaults to 7
@@ -20,51 +22,108 @@ if [ ! -d "$TELEMETRY_DIR" ]; then
     exit 0
 fi
 
-# Find JSONL files modified in the last N days.
-FILES=$(find "$TELEMETRY_DIR" -name 'otel-*.jsonl' -mtime "-$DAYS" | sort)
+# Gather JSONL files modified in the last N days. The collector writes
+# otel.jsonl and rotates to otel.jsonl.1, otel.jsonl.2, etc.
+FILES=$(find "$TELEMETRY_DIR" -name 'otel.jsonl*' -mtime "-$DAYS" 2>/dev/null | sort)
 
 if [ -z "$FILES" ]; then
     echo "No telemetry files in the last $DAYS day(s)." >&2
     exit 0
 fi
 
+# Redact common secret patterns before anything else sees the data.
+# Belt-and-braces vs. an agent having inlined a token into a command.
+scrub() {
+    sed -E \
+        -e 's/ghp_[A-Za-z0-9]{20,}/[REDACTED:ghp]/g' \
+        -e 's/gho_[A-Za-z0-9]{20,}/[REDACTED:gho]/g' \
+        -e 's/ghu_[A-Za-z0-9]{20,}/[REDACTED:ghu]/g' \
+        -e 's/ghs_[A-Za-z0-9]{20,}/[REDACTED:ghs]/g' \
+        -e 's/ghr_[A-Za-z0-9]{20,}/[REDACTED:ghr]/g' \
+        -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED:anthropic]/g' \
+        -e 's/sk-[A-Za-z0-9]{32,}/[REDACTED:openai]/g' \
+        -e 's/-----BEGIN [A-Z ]*PRIVATE KEY-----/[REDACTED:private-key]/g' \
+        -e 's/xox[baprs]-[A-Za-z0-9-]{10,}/[REDACTED:slack]/g' \
+        -e 's/AKIA[0-9A-Z]{16}/[REDACTED:aws-access-key]/g'
+}
+
+# jq program: flatten OTLP protocol JSON into per-event records, then
+# group by session.id and summarize.
+#
+# OTLP JSON structure (one object per exporter batch):
+#   { resourceLogs: [ { resource:{attributes:[...]}, scopeLogs:[ { logRecords:[ { attributes:[{key,value:{stringValue|intValue|...}}] } ] } ] } ] }
+#
+# attr($k): look up attribute value by key, unwrapping the typed value.
+JQ_PROGRAM=$(cat <<'JQ'
+def attr($k):
+  (.attributes // [])
+  | map(select(.key == $k))
+  | first
+  | .value
+  | (.stringValue // .intValue // .doubleValue // .boolValue // null);
+
+# Unwrap all log records from a single OTLP batch object.
+def log_records:
+  (.resourceLogs // [])[]
+  | (.scopeLogs // [])[]
+  | (.logRecords // [])[];
+
+# Flatten all records across all batches, extract fields we care about.
+[ .[]
+  | log_records
+  | {
+      event_name:    attr("event.name"),
+      session_id:    (attr("session.id") // "unknown"),
+      cost_usd:      attr("cost_usd"),
+      input_tokens:  attr("input_tokens"),
+      output_tokens: attr("output_tokens"),
+      duration_ms:   attr("duration_ms"),
+      prompt:        attr("prompt"),
+      error:         attr("error")
+    }
+]
+| group_by(.session_id)
+| map({
+    session:       (.[0].session_id),
+    turns:         ([.[] | select(.event_name == "api_request")] | length),
+    cost_usd:      ([.[] | select(.event_name == "api_request") | ((.cost_usd // "0") | tostring | tonumber? // 0)] | add // 0),
+    input_tokens:  ([.[] | select(.event_name == "api_request") | ((.input_tokens // 0) | tostring | tonumber? // 0)] | add // 0),
+    output_tokens: ([.[] | select(.event_name == "api_request") | ((.output_tokens // 0) | tostring | tonumber? // 0)] | add // 0),
+    errors:        ([.[] | select(.event_name == "api_error")] | length),
+    first_prompt:  ([.[] | select(.event_name == "user_prompt") | .prompt // empty] | first // "(no prompt logged)")
+  })
+| sort_by(-.cost_usd)
+JQ
+)
+
 echo "=== Cost & Observability Report — last $DAYS day(s) ==="
 echo
 
-# Extract events, aggregate per session.
-# Each line is an OTel log record; we care about user_prompt and api_request
-# events. Skip lines that aren't JSON (console exporter mixes in framing).
-cat $FILES \
-  | jq -c 'select(type == "object" and .attributes?)' 2>/dev/null \
-  | jq -s -r '
-    # Group events by session.id
-    group_by(.attributes["session.id"] // "unknown")
-    | map({
-        session:       (.[0].attributes["session.id"] // "unknown"),
-        turns:         ([.[] | select(.attributes["event.name"] == "api_request")] | length),
-        cost_usd:      ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.cost_usd      | tonumber? // 0)] | add // 0),
-        input_tokens:  ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.input_tokens  | tonumber? // 0)] | add // 0),
-        output_tokens: ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.output_tokens | tonumber? // 0)] | add // 0),
-        errors:        ([.[] | select(.attributes["event.name"] == "api_error")] | length),
-        first_prompt:  ([.[] | select(.attributes["event.name"] == "user_prompt") | .attributes.prompt // empty] | first // "(no prompt logged)")
-      })
-    | sort_by(-.cost_usd)
-    | .[]
-    | "session \(.session[0:12])  turns=\(.turns)  cost=$\(.cost_usd)  tok=\(.input_tokens)/\(.output_tokens)  err=\(.errors)\n  first: \(.first_prompt[0:80])"
-  '
+SUMMARY=$(cat $FILES | scrub | jq -c 'select(type == "object")' 2>/dev/null | jq -s "$JQ_PROGRAM" 2>/dev/null || echo "[]")
+
+if [ "$SUMMARY" = "[]" ] || [ -z "$SUMMARY" ]; then
+    echo "(no parseable events found in telemetry files)"
+    echo
+    echo "Raw file sizes:"
+    ls -lh $FILES
+    exit 0
+fi
+
+echo "$SUMMARY" | jq -r '
+    .[] |
+    "session \(.session[0:12])  turns=\(.turns)  cost=$\(.cost_usd)  tok=\(.input_tokens)/\(.output_tokens)  err=\(.errors)\n  first: \(.first_prompt[0:80])"
+'
 
 echo
 echo "=== Totals ==="
-cat $FILES \
-  | jq -c 'select(type == "object" and .attributes?)' 2>/dev/null \
-  | jq -s -r '
+echo "$SUMMARY" | jq -r '
     {
-      sessions:           ([.[] | (.attributes["session.id"] // "unknown")] | unique | length),
-      api_requests:       ([.[] | select(.attributes["event.name"] == "api_request")] | length),
-      api_errors:         ([.[] | select(.attributes["event.name"] == "api_error")] | length),
-      total_cost_usd:     ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.cost_usd      | tonumber? // 0)] | add // 0),
-      total_input_tokens: ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.input_tokens  | tonumber? // 0)] | add // 0),
-      total_output_tokens:([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.output_tokens | tonumber? // 0)] | add // 0)
+      sessions:            length,
+      api_requests:        ([.[] | .turns] | add // 0),
+      api_errors:          ([.[] | .errors] | add // 0),
+      total_cost_usd:      ([.[] | .cost_usd] | add // 0),
+      total_input_tokens:  ([.[] | .input_tokens] | add // 0),
+      total_output_tokens: ([.[] | .output_tokens] | add // 0)
     }
     | "sessions=\(.sessions)  requests=\(.api_requests)  errors=\(.api_errors)  cost=$\(.total_cost_usd)  tokens=\(.total_input_tokens) in / \(.total_output_tokens) out"
-  '
+'

--- a/scripts/cost-report.sh
+++ b/scripts/cost-report.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Weekly cost & observability summary over sandbox telemetry logs.
+#
+# Reads sandbox/telemetry/otel-*.jsonl (produced by sandbox/claude.sh)
+# and prints per-session totals: turn count, cost, tokens, first user
+# prompt. Used for the weekly cost review — see CLAUDE.md § Cost &
+# Observability.
+#
+# Usage: bash scripts/cost-report.sh [days]
+#   days defaults to 7
+
+set -euo pipefail
+
+DAYS="${1:-7}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TELEMETRY_DIR="$REPO_ROOT/sandbox/telemetry"
+
+if [ ! -d "$TELEMETRY_DIR" ]; then
+    echo "No telemetry directory at $TELEMETRY_DIR — nothing to report." >&2
+    exit 0
+fi
+
+# Find JSONL files modified in the last N days.
+FILES=$(find "$TELEMETRY_DIR" -name 'otel-*.jsonl' -mtime "-$DAYS" | sort)
+
+if [ -z "$FILES" ]; then
+    echo "No telemetry files in the last $DAYS day(s)." >&2
+    exit 0
+fi
+
+echo "=== Cost & Observability Report — last $DAYS day(s) ==="
+echo
+
+# Extract events, aggregate per session.
+# Each line is an OTel log record; we care about user_prompt and api_request
+# events. Skip lines that aren't JSON (console exporter mixes in framing).
+cat $FILES \
+  | jq -c 'select(type == "object" and .attributes?)' 2>/dev/null \
+  | jq -s -r '
+    # Group events by session.id
+    group_by(.attributes["session.id"] // "unknown")
+    | map({
+        session:       (.[0].attributes["session.id"] // "unknown"),
+        turns:         ([.[] | select(.attributes["event.name"] == "api_request")] | length),
+        cost_usd:      ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.cost_usd      | tonumber? // 0)] | add // 0),
+        input_tokens:  ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.input_tokens  | tonumber? // 0)] | add // 0),
+        output_tokens: ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.output_tokens | tonumber? // 0)] | add // 0),
+        errors:        ([.[] | select(.attributes["event.name"] == "api_error")] | length),
+        first_prompt:  ([.[] | select(.attributes["event.name"] == "user_prompt") | .attributes.prompt // empty] | first // "(no prompt logged)")
+      })
+    | sort_by(-.cost_usd)
+    | .[]
+    | "session \(.session[0:12])  turns=\(.turns)  cost=$\(.cost_usd)  tok=\(.input_tokens)/\(.output_tokens)  err=\(.errors)\n  first: \(.first_prompt[0:80])"
+  '
+
+echo
+echo "=== Totals ==="
+cat $FILES \
+  | jq -c 'select(type == "object" and .attributes?)' 2>/dev/null \
+  | jq -s -r '
+    {
+      sessions:           ([.[] | (.attributes["session.id"] // "unknown")] | unique | length),
+      api_requests:       ([.[] | select(.attributes["event.name"] == "api_request")] | length),
+      api_errors:         ([.[] | select(.attributes["event.name"] == "api_error")] | length),
+      total_cost_usd:     ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.cost_usd      | tonumber? // 0)] | add // 0),
+      total_input_tokens: ([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.input_tokens  | tonumber? // 0)] | add // 0),
+      total_output_tokens:([.[] | select(.attributes["event.name"] == "api_request") | (.attributes.output_tokens | tonumber? // 0)] | add // 0)
+    }
+    | "sessions=\(.sessions)  requests=\(.api_requests)  errors=\(.api_errors)  cost=$\(.total_cost_usd)  tokens=\(.total_input_tokens) in / \(.total_output_tokens) out"
+  '


### PR DESCRIPTION
## Summary

Closes #150 — enables Claude Code OpenTelemetry output from the sandbox and adds a weekly cost-review workflow, so autonomous-agent spend becomes visible and bounded.

## What's in

### Sandbox telemetry (OTel Collector sidecar)
- **`sandbox/docker-compose.yml`** — adds an `otel-collector` service (`otel/opentelemetry-collector-contrib:0.113.0`) alongside the agent. Agent emits OTLP/gRPC to `otel-collector:4317` (`OTEL_METRICS_EXPORTER=otlp`, `OTEL_LOGS_EXPORTER=otlp`, `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`). Log detail level: `OTEL_LOG_TOOL_DETAILS=1` (tool inputs), `OTEL_LOG_USER_PROMPTS=1` (prompt text for correlation). Explicitly **not** `OTEL_LOG_TOOL_CONTENT` — that would log file contents + command output, way too much surface area.
- **`sandbox/otel-collector-config.yaml`** *(new)* — collector config. OTLP receivers on `:4317` (gRPC) and `:4318` (HTTP), batch processor (5 s / 100 records), file exporter to `/var/log/claude-telemetry/otel.jsonl` with rotation (50 MB × 10 backups, 30 days). Shared bind mount `./telemetry:/var/log/claude-telemetry` is mounted into both services so the host sees the files at `sandbox/telemetry/`.
- **`sandbox/run.sh`** — `mkdir -p` the host telemetry dir before docker compose mounts it.
- **`sandbox/claude.sh`** — simple wrapper now; no stdio massaging needed because the collector captures telemetry out-of-band.

### Why a collector instead of the console exporter

First pass of this PR used `OTEL_*_EXPORTER=console` + an `sh` wrapper that scrubbed stderr. That didn't work: Claude Code's console exporter writes a multi-line pretty-printed JS object to **stdout** (not JSONL, not stderr), so `jq` couldn't parse any of it and `cost-report.sh` produced an empty report. The collector approach gives us clean single-line OTLP JSON that the file exporter rotates automatically.

### Weekly cost review
- **`scripts/cost-report.sh [days]`** (default 7 days) — `jq`-based summary over `sandbox/telemetry/otel.jsonl*`:
  - Walks OTLP structure: `resourceLogs[].scopeLogs[].logRecords[]`, unwraps typed attribute values (`stringValue` / `intValue` / `doubleValue` / `boolValue`)
  - Per-session totals: turn count, cost, tokens (in/out), error count, first user prompt
  - Sorted by cost descending; grand totals line at the end
- **Secret scrubbing runs at read time inside this script** (moved out of `claude.sh`) via a `sed` pipeline covering `ghp_*`, `gho_*`, `ghu_*`, `ghs_*`, `ghr_*`, `sk-ant-*`, `sk-*`, `xox[baprs]-*`, `AKIA*`, private keys. This way scrubbing applies to any file the collector produced, not only ones written through a specific wrapper.

### Docs
- **New `sandbox/README.md`** — sandbox usage overview + full Cost & Observability guide (turn caps, collector architecture with ASCII diagram, weekly review, security notes). Deliberately placed here instead of CLAUDE.md so normal dev sessions don't load 60 lines of sandbox-ops context.
- **`CLAUDE.md`** — one-line pointer to `sandbox/README.md`; new "telemetry" row in the "what goes where" table.
- **`.gitignore`** — `sandbox/telemetry/`.

### Drive-by cleanup
- **`.claude/agents/pm.md`** — removed duplicated status/type/priority tables. CLAUDE.md has the canonical spec and is auto-loaded into every session; the inline copy was pure drift risk. Replaced with a one-line pointer.

## What's NOT in

- **`maxTurns` changes** — already set in all three agent frontmatters (PM=30, Developer=100, Reviewer=50) from #146, matching the issue's spec. Nothing to change.
- **`OTEL_LOG_TOOL_CONTENT`** — off by design. Logs file contents + command output, too much exposure.

## Test plan

- [x] `pre-commit` passes on commit
- [x] All scripts parse (`bash -n`)
- [x] `scripts/cost-report.sh` against empty dir → clean "nothing to report" exit
- [x] End-to-end validation in the sandbox: `sandbox/run.sh` → interactive Claude Code session → `sandbox/telemetry/otel.jsonl` produced on the host (19 KB, 4 lines), all lines parse as JSON, event names `user_prompt` / `api_request` / `api_error` present
- [x] `cost-report.sh 1` on real telemetry → correctly extracts per-session cost (`$0.07468525`), input/output tokens (`343 / 20`), error count, first user prompt
- [x] Scrub end-to-end: injected `ghp_*`, `sk-ant-*`, and `AKIA*` fake tokens into a synthetic telemetry file, ran `cost-report.sh` against it → all three redacted in output, raw token strings absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)