### PR TITLE
chore(agents): use inherit model and add cyy2 investigation guidance

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -2,7 +2,7 @@
 name: developer
 description: "Developer agent that implements GitHub issues end-to-end using git worktrees. Fetches issue, investigates, proposes a plan, implements with tests, runs self-review, and opens a PR. Use when working on a GitHub issue, fixing bugs, or implementing features."
 tools: "Read, Write, Edit, Glob, Grep, Bash"
-model: sonnet
+model: inherit
 maxTurns: 100
 skills: "simplify, write-test, run-on-cyy2, mlflow-reader, mlflow-failure-analyzer"
 color: cyan
@@ -68,6 +68,8 @@ The `data/` symlink avoids duplicating large datasets.
 
 **For refactors:** understand current structure, identify all callers/dependents, verify test coverage.
 
+**For server-side issues (GPU, OOM, Ray, sweeps):** use `/run-on-cyy2` to check server state, Ray logs, MLflow artifacts, or run diagnostic commands. Relevant for issues involving production sweep failures, memory leaks, or GPU utilization.
+
 Checklist before proceeding:
 - Located all relevant source files
 - Understood current behavior
@@ -75,6 +77,7 @@ Checklist before proceeding:
 - Found similar patterns to follow
 - Identified tests that need updating
 - Assessed blast radius
+- (If server-side) Checked cyy2 logs/state as needed
 
 ### Phase 4: Propose Plan (APPROVAL GATE)
 

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,7 +2,7 @@
 name: pm
 description: "Project Manager that triages GitHub issues, assigns labels/priority, builds dependency graphs, and produces status reports. Use when managing the backlog, triaging issues, checking project status, or planning work."
 tools: "Read, Glob, Grep, Bash"
-model: sonnet
+model: inherit
 maxTurns: 30
 color: orange
 ---

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: "Code reviewer that reviews PRs for correctness, style compliance, test coverage, and code quality. Posts structured findings on GitHub with severity ratings. Use when a PR needs review or is labeled status/needs-review."
 tools: "Read, Glob, Grep, Bash"
-model: sonnet
+model: inherit
 maxTurns: 50
 skills: "simplify, run-on-cyy2, mlflow-reader, mlflow-failure-analyzer"
 color: green

--- a/.claude/skills/run-on-cyy2/SKILL.md
+++ b/.claude/skills/run-on-cyy2/SKILL.md
@@ -126,9 +126,18 @@ ssh cyy2 "find /root/stgym/mlruns -name 'training_error.txt' -path '*<run_id>*'"
 scp cyy2:<path-from-above> /tmp/<prefix>/training_error.txt
 ```
 
+## Installing Dependencies
+
+The server does not have `uv` installed. Use `pip` for package installation:
+
+```bash
+ssh cyy2 "cd /root/stgym && source .venv/bin/activate && pip install <package>"
+```
+
 ## Notes
 
 - Always reuse the `run` screen; never create a second one unless the user explicitly asks.
 - If a new screen must be created, activate the venv before launching any Python command.
 - MLflow tracking server runs at `http://127.0.0.1:5001` on the server (port-forwarded locally).
 - Sweep configs live in `conf/exp/*.yaml`; design spaces in `conf/design_space/`.
+- Use `pip install` for dependencies — `uv` is not available on cyy2.


### PR DESCRIPTION
## Summary

- Change model from `sonnet` to `inherit` for all sub-agents (pm, developer, reviewer) so they use the same model as the parent conversation
- Add server-side investigation guidance to developer agent for GPU/OOM/Ray issues
- Document that cyy2 uses `pip` (not `uv`) for package installation

## Test plan

- [ ] Verify sub-agents inherit the model correctly when spawned
- [ ] Verify developer agent can use `/run-on-cyy2` for investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)