### PR TITLE
feat: add layer_type design dimension experiment config

### DIFF
--- a/conf/exp/layer_type.yaml
+++ b/conf/exp/layer_type.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+
+design_dimension: model.layer_type
+design_choices: ['gcnconv', 'ginconv', 'sageconv']
+
+mlflow:
+  experiment_name: layer_type


### PR DESCRIPTION
## Summary

- Adds `conf/exp/layer_type.yaml` to enable sweeps over GNN layer types

## Design Choices

- `gcnconv` — Graph Convolutional Network
- `ginconv` — Graph Isomorphism Network  
- `sageconv` — GraphSAGE

## Usage

```bash
python run_rct.py +exp=layer_type design_space=graph_clf resource=gpu-6 sample_size=50
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)