### PR TITLE
infra: add PLC rule set to ruff linting

### DIFF
--- a/get_pos_maxpsan.py
+++ b/get_pos_maxpsan.py
@@ -1,10 +1,10 @@
+import argparse
+
 from stgym.data_loader import get_dataset_class
 from stgym.utils import get_coord_span
 
 
 def main():
-    import argparse
-
     parser = argparse.ArgumentParser(
         description="Get maximum coordinate span for a dataset"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,14 @@ target-version = "py312"
 exclude = [".claude"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP"]
+select = ["E", "F", "I", "UP", "PLC"]
 ignore = ["E501", "E402", "F821"]
+
+[tool.ruff.lint.per-file-ignores]
+# Marimo notebooks require imports inside @app.cell functions by design
+"rct_experiment_analysis.py" = ["PLC0415"]
+# Scripts use lazy/conditional imports for ergonomic reasons
+"scripts/**" = ["PLC0415"]
 
 [tool.uv]
 find-links = ["https://data.pyg.org/whl/torch-2.7.0+cpu.html"]

--- a/stgym/data_loader/human_pancreas.py
+++ b/stgym/data_loader/human_pancreas.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import torch
 from torch_geometric.data import Data
@@ -64,8 +65,6 @@ class HumanPancreasDataset(AbstractDataset):
             # Handle NaN values in the feature matrix
             # Check if there are any NaN values
             if pd.isnull(features).any():
-                import numpy as np
-
                 nan_count = np.isnan(features).sum()
                 total_features = features.shape[0] * features.shape[1]
                 print(

--- a/stgym/data_loader/inflammatory_skin.py
+++ b/stgym/data_loader/inflammatory_skin.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import scipy.sparse
 import torch
 from torch_geometric.data import Data
 
@@ -125,8 +126,6 @@ class InflammatorySkinDataset(AbstractDataset):
                 shape = (n_rows, n_cols)
 
             # Create sparse matrix
-            import scipy.sparse
-
             sparse_matrix = scipy.sparse.csr_matrix(
                 (data, indices, indptr), shape=shape
             )

--- a/stgym/data_loader/mouse_kidney.py
+++ b/stgym/data_loader/mouse_kidney.py
@@ -1,4 +1,5 @@
 import os
+import resource
 from pathlib import Path
 
 import pandas as pd
@@ -12,8 +13,6 @@ from .base import AbstractDataset
 
 def _mem_gb():
     """Return current process RSS in GB."""
-    import resource
-
     rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     # macOS reports bytes, Linux reports KB
     if os.uname().sysname == "Darwin":

--- a/stgym/mem_utils.py
+++ b/stgym/mem_utils.py
@@ -18,6 +18,8 @@ Features:
 from typing import Any
 
 import torch
+import torch_geometric.transforms as T
+from torch_geometric.data import Batch, Data
 
 from stgym.cache import DatasetStatistics, generate_cache_key, load_cached_statistics
 from stgym.config_schema import (
@@ -169,9 +171,6 @@ def _initialize_model_with_dummy_data(
         num_features: Number of input features
         device: Device to create dummy data on
     """
-    import torch_geometric.transforms as T
-    from torch_geometric.data import Batch, Data
-
     # Create minimal dummy graph
     dummy_x = torch.randn(5, num_features).to(device)
     dummy_edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=torch.long).to(

--- a/tests/dataloader/test_loader.py
+++ b/tests/dataloader/test_loader.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from torch_geometric.data import Data
 
 from stgym.config_schema import DataLoaderConfig, TaskConfig
 from stgym.data_loader import (
@@ -140,7 +141,6 @@ class TestSTDataModuleNaNDetection:
     @property
     def mock_dataset_with_nans(self):
         """Create a mock dataset with NaN values in features"""
-        from torch_geometric.data import Data
 
         # Create a simple mock dataset with NaN values
         class MockDataset:
@@ -201,7 +201,6 @@ class TestDropLastBehavior:
     @property
     def small_mock_dataset(self):
         """Create a small mock dataset to reproduce drop_last issues."""
-        from torch_geometric.data import Data
 
         class MockDataset:
             def __init__(self, num_samples):

--- a/tests/test_rct_utils.py
+++ b/tests/test_rct_utils.py
@@ -9,6 +9,7 @@ import pytest
 from stgym.rct_utils import (
     DESIGN_DIM_TO_MLFLOW_PATH,
     aggregate_kfold_metrics,
+    analyze_experiment,
     compute_within_group_ranks,
     filter_complete_groups,
     runs_to_dataframe,
@@ -232,8 +233,6 @@ class TestAnalyzeExperiment:
 
     def test_returns_empty_df_when_no_runs(self, mock_fetch_runs: MagicMock):
         """Verify empty DataFrame is returned when no runs exist."""
-        from stgym.rct_utils import analyze_experiment
-
         mock_fetch_runs.return_value = []
 
         result = analyze_experiment(
@@ -246,8 +245,6 @@ class TestAnalyzeExperiment:
 
     def test_full_pipeline_single_dimension(self, mock_fetch_runs: MagicMock):
         """Verify full analysis pipeline runs correctly for a single design dimension."""
-        from stgym.rct_utils import analyze_experiment
-
         runs = []
         for i in range(4):
             run = MockRun(
@@ -275,8 +272,6 @@ class TestAnalyzeExperiment:
 
     def test_multiple_dimensions_analyzed_separately(self, mock_fetch_runs: MagicMock):
         """Verify runs with different design dimensions are analyzed independently."""
-        from stgym.rct_utils import analyze_experiment
-
         dim_a = "model.act"
         param_a = DESIGN_DIM_TO_MLFLOW_PATH[dim_a]
         dim_b = "train.optim.optimizer"
@@ -319,8 +314,6 @@ class TestAnalyzeExperimentWithRealisticData:
 
     def test_with_regular_runs_only(self, mock_fetch_runs: MagicMock, regular_runs):
         """Verify analysis works with regular (non-k-fold) runs."""
-        from stgym.rct_utils import analyze_experiment
-
         mock_fetch_runs.return_value = regular_runs
 
         result = analyze_experiment(
@@ -341,8 +334,6 @@ class TestAnalyzeExperimentWithRealisticData:
 
     def test_with_kfold_runs_only(self, mock_fetch_runs: MagicMock, kfold_runs):
         """Verify analysis correctly aggregates k-fold runs by mean metric."""
-        from stgym.rct_utils import analyze_experiment
-
         mock_fetch_runs.return_value = kfold_runs
 
         result = analyze_experiment(
@@ -361,8 +352,6 @@ class TestAnalyzeExperimentWithRealisticData:
 
     def test_with_mixed_runs(self, mock_fetch_runs: MagicMock, mixed_runs):
         """Verify analysis handles mixed regular and k-fold runs."""
-        from stgym.rct_utils import analyze_experiment
-
         mock_fetch_runs.return_value = mixed_runs
 
         result = analyze_experiment(
@@ -382,8 +371,6 @@ class TestAnalyzeExperimentWithRealisticData:
         self, _mock_fetch_runs: MagicMock, kfold_runs
     ):
         """Verify k-fold aggregation computes correct mean metrics."""
-        from stgym.rct_utils import aggregate_kfold_metrics, runs_to_dataframe
-
         df = runs_to_dataframe(kfold_runs, metric_name="test_roc_auc")
         aggregated = aggregate_kfold_metrics(df)
 
@@ -401,12 +388,6 @@ class TestAnalyzeExperimentWithRealisticData:
         self, mock_fetch_runs: MagicMock, kfold_runs
     ):
         """Verify a failed fold marks the entire aggregated group as failed."""
-        from stgym.rct_utils import (
-            aggregate_kfold_metrics,
-            filter_complete_groups,
-            runs_to_dataframe,
-        )
-
         kfold_runs_with_failure = list(kfold_runs)
         kfold_runs_with_failure[0] = MockRun(
             data=kfold_runs_with_failure[0].data,


### PR DESCRIPTION
Closes #168

## Summary
- Adds `PLC` to ruff `select` in `pyproject.toml`, enabling Pylint Convention rules (notably `PLC0415` — import-outside-top-level)
- Adds `per-file-ignores` for `rct_experiment_analysis.py` (Marimo cells require imports inside functions by design) and `scripts/**`
- Fixes all 23 existing `PLC0415` violations by moving imports to module top-level in `stgym/`, `tests/`, and `get_pos_maxpsan.py`

## Test plan
- [x] `ruff check .` passes with no violations
- [x] `pytest tests/ -m 'not slow'` passes (231 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)