### PR TITLE
infra: add marimo check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,8 @@ repos:
         files: \.ipynb$
         language: system
         entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
+      - id: marimo-check
+        name: marimo-check
+        language: system
+        entry: uv run marimo check --ignore-scripts
+        types: [python]


### PR DESCRIPTION
Closes #165

## Summary
- Adds a `marimo-check` local hook to `.pre-commit-config.yaml`
- Runs `marimo check --ignore-scripts` on all `.py` files; non-marimo files are silently skipped (exit 0) so no false positives
- Catches invalid cell dependencies, syntax errors, and circular references in Marimo notebooks before commit

## Test plan
- [x] `pre-commit run marimo-check --all-files` passes on the current codebase
- [x] Hook fails (exit 1) on a notebook with a circular cell dependency — verified by creating a minimal marimo file with `a = b + 1` / `b = a + 1` cycle and running `pre-commit run marimo-check --files <file>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)