### PR TITLE
fix(model): prevent post_mp_layer.dims mutation across k-fold runs

### DIFF
--- a/stgym/model.py
+++ b/stgym/model.py
@@ -23,9 +23,11 @@ class STGraphClassifier(torch.nn.Module):
         self.global_pooling = get_pooling_operator(cfg.global_pooling)
 
         # dim_out should be passed to MLP
-        cfg.post_mp_layer.dims.append(dim_out)
+        post_mp_config = cfg.post_mp_layer.model_copy(
+            update={"dims": cfg.post_mp_layer.dims + [dim_out]}
+        )
         # TODO: what does it mean for dim equal -1? when to use it?
-        self.post_mp = MLP(-1, cfg.post_mp_layer, cfg.mem)
+        self.post_mp = MLP(-1, post_mp_config, cfg.mem)
 
     def forward(self, batch: Data) -> tuple[Data, Tensor, list[dict[str, Tensor]]]:
         """return the batch before global pooling and the predictions by post MP layers"""
@@ -48,9 +50,11 @@ class STNodeClassifier(torch.nn.Module):
             dim_in=dim_in, layer_configs=cfg.mp_layers, mem_config=cfg.mem
         )
         # dim_out should be passed to MLP
-        cfg.post_mp_layer.dims.append(dim_out)
+        post_mp_config = cfg.post_mp_layer.model_copy(
+            update={"dims": cfg.post_mp_layer.dims + [dim_out]}
+        )
         # TODO: what does it mean for dim equal -1? when to use it?
-        self.post_mp = MLP(-1, cfg.post_mp_layer, cfg.mem)
+        self.post_mp = MLP(-1, post_mp_config, cfg.mem)
 
     def forward(self, batch: Data) -> tuple[Data, Tensor, list[dict[str, Tensor]]]:
         check_edge_index(batch)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+import pytest
 from torch import Tensor
 from torch_geometric.data import Data
 
@@ -40,6 +41,46 @@ class TestSTGraphClassifier(BatchLoaderMixin):
         assert len(other_loss) == 2
         for loss in other_loss:
             assert isinstance(loss, dict)
+
+
+@pytest.mark.parametrize(
+    "model_cls,cfg_factory",
+    [
+        (
+            STGraphClassifier,
+            lambda: GraphClassifierModelConfig(
+                mp_layers=[MessagePassingConfig(layer_type="gcnconv", pooling=None)],
+                global_pooling="mean",
+                post_mp_layer=PostMPConfig(dims=[32]),
+            ),
+        ),
+        (
+            STNodeClassifier,
+            lambda: NodeClassifierModelConfig(
+                mp_layers=[MessagePassingConfig(layer_type="gcnconv", pooling=None)],
+                post_mp_layer=PostMPConfig(dims=[32]),
+            ),
+        ),
+    ],
+)
+class TestConfigImmutability(BatchLoaderMixin):
+    """Verify that model construction does not mutate the shared PostMPConfig."""
+
+    def test_dims_unchanged_after_construction(self, model_cls, cfg_factory):
+        """Config dims must not be mutated when building the model."""
+        cfg = cfg_factory()
+        original_dims = list(cfg.post_mp_layer.dims)
+        model_cls(self.num_features, self.num_classes, cfg)
+        assert cfg.post_mp_layer.dims == original_dims
+
+    def test_repeated_construction_stable_dims(self, model_cls, cfg_factory):
+        """Simulates k-fold: constructing the model N times with the same config
+        must not accumulate trailing dim_out values."""
+        cfg = cfg_factory()
+        original_dims = list(cfg.post_mp_layer.dims)
+        for _ in range(5):
+            model_cls(self.num_features, self.num_classes, cfg)
+        assert cfg.post_mp_layer.dims == original_dims
 
 
 class TestSTNodeClassifier(BatchLoaderMixin):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -62,6 +62,7 @@ class TestSTGraphClassifier(BatchLoaderMixin):
             ),
         ),
     ],
+    ids=["graph_clf", "node_clf"],
 )
 class TestConfigImmutability(BatchLoaderMixin):
     """Verify that model construction does not mutate the shared PostMPConfig."""
@@ -70,8 +71,11 @@ class TestConfigImmutability(BatchLoaderMixin):
         """Config dims must not be mutated when building the model."""
         cfg = cfg_factory()
         original_dims = list(cfg.post_mp_layer.dims)
-        model_cls(self.num_features, self.num_classes, cfg)
+        model = model_cls(self.num_features, self.num_classes, cfg)
         assert cfg.post_mp_layer.dims == original_dims
+        # Verify dim_out is wired correctly via a forward pass
+        _, pred, _ = model(self.load_batch())
+        assert pred.shape[-1] == self.num_classes
 
     def test_repeated_construction_stable_dims(self, model_cls, cfg_factory):
         """Simulates k-fold: constructing the model N times with the same config
@@ -79,7 +83,9 @@ class TestConfigImmutability(BatchLoaderMixin):
         cfg = cfg_factory()
         original_dims = list(cfg.post_mp_layer.dims)
         for _ in range(5):
-            model_cls(self.num_features, self.num_classes, cfg)
+            model = model_cls(self.num_features, self.num_classes, cfg)
+            _, pred, _ = model(self.load_batch())
+            assert pred.shape[-1] == self.num_classes
         assert cfg.post_mp_layer.dims == original_dims
 
 


### PR DESCRIPTION
## Problem

`cfg.post_mp_layer.dims.append(dim_out)` in `STGraphClassifier` and `STNodeClassifier` mutates the shared `PostMPConfig` object. In k-fold CV, the same config is reused across folds, causing dims to accumulate trailing `dim_out` values each fold — corrupting both model architecture and logged MLflow params.

Fixes #169

## Solution

Replace in-place mutation with `model_copy(update=...)` to create a per-instantiation copy of the config with `dim_out` appended. The original config is untouched.

## Changes

- `stgym/model.py` — replace `cfg.post_mp_layer.dims.append(dim_out)` with `post_mp_config = cfg.post_mp_layer.model_copy(update={"dims": cfg.post_mp_layer.dims + [dim_out]})` in both `STGraphClassifier` and `STNodeClassifier`
- `tests/test_model.py` — add `TestConfigImmutability` parametrized over both model classes: verifies dims unchanged after single construction and after 5 repeated constructions (k-fold simulation)

## Testing

- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/ -m 'not slow'` passes (235 tests)
- [x] `TestConfigImmutability` confirms dims stay unchanged after single and repeated (×5) model construction

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>