### PR TITLE
infra(sandbox): install jq in Docker image

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ripgrep \
     procps \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # gh CLI


### PR DESCRIPTION
## Problem

`jq` was missing from the sandbox Docker image, preventing JSON piping from CLI tools.

Fixes #160

## Solution

Added `jq` to the `apt-get install` list in `sandbox/Dockerfile`.

## Changes

- `sandbox/Dockerfile` — add `jq` to system dependencies

## Testing

- [x] `pre-commit run --all-files` passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>