### PR TITLE
fix(rct): simplify error handling in run_exp

### DIFF
--- a/stgym/rct/run.py
+++ b/stgym/rct/run.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 from typing import Optional
 
@@ -123,14 +122,7 @@ def run_exp(
             )
         except Exception as e:
             log_training_error(e, logger)
-            if isinstance(e, torch.cuda.OutOfMemoryError):
-                # Force-kill the Ray worker process so its CUDA context is destroyed
-                # and the GPU slot is released. A normal raise only returns the worker
-                # to the pool, permanently claiming the slot.
-                # https://github.com/xiaohan2012/stgym/pull/99
-                if logger is not None:
-                    logger.experiment.set_terminated(logger.run_id, status="FAILED")
-                os._exit(1)
+            raise
     else:
         logz_logger.info("Evaluation mode: k-fold cross validation.")
         # k-fold split - create separate logger for each fold
@@ -176,12 +168,6 @@ def run_exp(
                 )
             except Exception as e:
                 log_training_error(e, fold_logger, f" in fold {fold}")
-                if isinstance(e, torch.cuda.OutOfMemoryError):
-                    # https://github.com/xiaohan2012/stgym/pull/99
-                    if fold_logger is not None:
-                        fold_logger.experiment.set_terminated(
-                            fold_logger.run_id, status="FAILED"
-                        )
-                    os._exit(1)
+                raise
 
     return True

--- a/tests/rct/test_run.py
+++ b/tests/rct/test_run.py
@@ -230,32 +230,6 @@ class TestRunExp:
         assert result is True
         mock_train.assert_called_once()
 
-    @pytest.mark.parametrize("split_type", ["regular", "kfold"])
-    @patch("stgym.rct.run.os._exit")
-    @patch("stgym.rct.run.logz_logger")
-    @patch("stgym.rct.run.log_params_and_config_in_mlflow")
-    def test_oom_kills_worker_process(
-        self, mock_log_params, mock_logger, mock_exit, split_type
-    ):
-        """OOM should close the MLflow run then force-kill the worker process"""
-        exp_cfg = self._create_experiment_config(
-            "graph_clf", data_loader_type=split_type
-        )
-        mlflow_cfg = MLFlowConfig(track=True)
-        mock_tl_logger = Mock()
-
-        with (
-            patch.object(MLFlowConfig, "create_tl_logger", return_value=mock_tl_logger),
-            patch("stgym.rct.run.train") as mock_train,
-        ):
-            mock_train.side_effect = torch.cuda.OutOfMemoryError("OOM")
-            run_exp(exp_cfg, mlflow_cfg)
-
-        mock_tl_logger.experiment.set_terminated.assert_called_with(
-            mock_tl_logger.run_id, status="FAILED"
-        )
-        mock_exit.assert_called_with(1)
-
     @pytest.mark.parametrize(
         "mock_target,exception_msg",
         [
@@ -278,12 +252,9 @@ class TestRunExp:
         with patch(mock_target) as mock_component:
             mock_component.side_effect = RuntimeError(exception_msg)
 
-            result = run_exp(
-                exp_cfg, mlflow_config, metadata_for_tag=self.metadata_for_tag
-            )
+            with pytest.raises(RuntimeError, match=exception_msg):
+                run_exp(exp_cfg, mlflow_config, metadata_for_tag=self.metadata_for_tag)
 
-            # Should still return True even with error
-            assert result is True
             # Error should be logged
             mock_logger.error.assert_called_once()
             error_call = mock_logger.error.call_args[0][0]


### PR DESCRIPTION
## Problem

OOM-specific error handling in `run_exp` called `set_terminated()` and `os._exit(1)` only for `torch.cuda.OutOfMemoryError`, leaving all other exceptions silently swallowed — MLflow runs stuck in `RUNNING` state and callers receiving `True` despite failure.

Fixes #130
Fixes #107

## Solution

Both special-case behaviours are now redundant:
- `set_terminated(..., "FAILED")` — PyTorch Lightning's `MLFlowLogger.finalize("failed")` already calls this for **all** exceptions before they propagate out of `train()`.
- `os._exit(1)` — `max_calls=1` on the Ray remote already recycles the worker process after every task, so the GPU slot is always released.

Replace both `except` blocks with a plain `raise`, so all exceptions propagate correctly.

## Changes

- `stgym/rct/run.py` — remove OOM gate and `os._exit(1)` from both the regular and k-fold except blocks; remove unused `import os`
- `tests/rct/test_run.py` — delete `test_oom_kills_worker_process` (tests removed behaviour); update `test_error_handling` to expect `RuntimeError` raised instead of swallowed

## Testing

- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/ -m 'not slow'` passes (7/7 in `tests/rct/test_run.py`)
- [ ] Run a full sweep on cyy2 and verify `sweep_status.py` reports zero stale runs

Co-Authored-By: Claude <noreply@anthropic.com>