### PR TITLE
docs(sweep-status): consolidate two-step workflow into single command

### DIFF
--- a/.claude/skills/sweep-status/SKILL.md
+++ b/.claude/skills/sweep-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sweep-status
-description: Check sweep progress on cyy2 GPU server. Runs sweep_status.py in a dedicated screen session and saves output to persistent log files. Use when checking experiment sweep status, monitoring running sweeps, or diagnosing stale runs.
+description: Check sweep progress on cyy2 GPU server. Runs sweep_status.py remotely and saves output to local log files. Use when checking experiment sweep status, monitoring running sweeps, or diagnosing stale runs.
 ---
 
 # sweep-status
@@ -16,58 +16,34 @@ Check sweep progress on the cyy2 GPU server with persistent logging.
 
 ## Workflow
 
-### Step 1: Submit command (do this first)
-
-The script may take a minute or more to run. Just submit the command and let it run.
+Run the script and capture output in a single command:
 
 ```bash
-# Ensure screen exists, then send command
-ssh cyy2 "screen -ls | grep sweep-status" || ssh cyy2 "screen -dmS sweep-status bash -c 'cd /root/stgym && source .venv/bin/activate && exec bash'"
-
-# Submit the command (returns immediately)
-ssh cyy2 "screen -S sweep-status -X stuff 'python scripts/sweep_status.py -i <experiment-id> [options]\n'"
-```
-
-### Step 2: Check output (do this later)
-
-After the script finishes (typically 30-60 seconds), capture and save the output.
-
-```bash
-# Capture screen output to local log
 mkdir -p logs/sweep-status
-ssh cyy2 "screen -S sweep-status -X hardcopy /tmp/sweep_status_dump && cat /tmp/sweep_status_dump" > "logs/sweep-status/<experiment-id>-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
-
-# Display the output
-cat logs/sweep-status/<experiment-id>-*.log | tail -100
+ssh cyy2 "cd /root/stgym && source .venv/bin/activate && python scripts/sweep_status.py -i <experiment-id> [options]" | tee "logs/sweep-status/<experiment-id>-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
 ```
 
 ## Examples
 
-### Submit status check by experiment ID
-
-```bash
-ssh cyy2 "screen -ls | grep sweep-status" || ssh cyy2 "screen -dmS sweep-status bash -c 'cd /root/stgym && source .venv/bin/activate && exec bash'"
-ssh cyy2 "screen -S sweep-status -X stuff 'python scripts/sweep_status.py -i 42\n'"
-```
-
-### Submit status check by experiment name
-
-```bash
-ssh cyy2 "screen -S sweep-status -X stuff 'python scripts/sweep_status.py -n sweep-all-20260323\n'"
-```
-
-### Submit with custom options
-
-```bash
-ssh cyy2 "screen -S sweep-status -X stuff 'python scripts/sweep_status.py -i 42 --sample-size 50 --stale-threshold 30\n'"
-```
-
-### Capture output later
+### Check by experiment ID
 
 ```bash
 mkdir -p logs/sweep-status
-ssh cyy2 "screen -S sweep-status -X hardcopy /tmp/sweep_status_dump && cat /tmp/sweep_status_dump" > "logs/sweep-status/42-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
-cat logs/sweep-status/42-*.log | tail -100
+ssh cyy2 "cd /root/stgym && source .venv/bin/activate && python scripts/sweep_status.py -i 42" | tee "logs/sweep-status/42-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
+```
+
+### Check by experiment name
+
+```bash
+mkdir -p logs/sweep-status
+ssh cyy2 "cd /root/stgym && source .venv/bin/activate && python scripts/sweep_status.py -n sweep-all-20260323" | tee "logs/sweep-status/sweep-all-20260323-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
+```
+
+### Check with custom options
+
+```bash
+mkdir -p logs/sweep-status
+ssh cyy2 "cd /root/stgym && source .venv/bin/activate && python scripts/sweep_status.py -i 42 --sample-size 50 --stale-threshold 30" | tee "logs/sweep-status/42-$(date -u +'%Y-%m-%dT%H:%M:%SZ').log"
 ```
 
 ## Output Interpretation
@@ -82,7 +58,6 @@ The script outputs a table per design dimension showing:
 
 ## Notes
 
-- Uses dedicated `sweep-status` screen to avoid interfering with the main `run` session
-- Logs persist in `logs/sweep-status/` for later analysis
+- Logs are saved locally to `logs/sweep-status/` for later analysis
 - The MLflow tracking server on cyy2 runs at `http://127.0.0.1:5001`
 - A RUNNING run is considered stale when its age exceeds the stale threshold (default 20 minutes)


### PR DESCRIPTION
## Problem

The `sweep-status` skill used a two-step screen-based workflow (submit command, then fetch output later) based on the assumption that `sweep_status.py` is slow. This assumption is incorrect — the script runs quickly.

## Solution

Replace the submit+capture steps with a single `ssh | tee` command that runs the script remotely and saves output locally in one go.

## Changes

- `.claude/skills/sweep-status/SKILL.md` — replace two-step screen workflow with a single consolidated command; update examples and notes accordingly

## Testing

- [ ] Manual verification: skill instructions are correct and self-consistent

Co-Authored-By: Claude <noreply@anthropic.com>