### PR TITLE
docs: clarify MLflow port config for cyy2 vs local

### DIFF
--- a/.claude/skills/sweep-status/SKILL.md
+++ b/.claude/skills/sweep-status/SKILL.md
@@ -59,5 +59,5 @@ The script outputs a table per design dimension showing:
 ## Notes
 
 - Logs are saved locally to `logs/sweep-status/` for later analysis
-- The MLflow tracking server on cyy2 runs at `http://127.0.0.1:5001`
+- The MLflow tracking server on cyy2 runs at `http://127.0.0.1:5000`
 - A RUNNING run is considered stale when its age exceeds the stale threshold (default 20 minutes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,10 @@ bash scripts/test_on_gpu.sh    # quick GPU smoke test
 
 ### MLflow Tracking
 
-Default local MLflow URI is `http://127.0.0.1:5000`. Start the server with the launch script if needed (see `scripts/`).
+- **On cyy2**: MLflow server runs on port **5000** (`http://127.0.0.1:5000`)
+- **From local**: Use port **5001** (`http://127.0.0.1:5001`) via SSH port forwarding. If queries fail with "connection refused", the port forwarding is likely not set up.
+
+Start the server with the launch script if needed (see `scripts/`).
 
 ## Claude Code Skills
 


### PR DESCRIPTION
## Summary

- Document MLflow port differences: 5000 on cyy2, 5001 from local via SSH forwarding
- Add troubleshooting note for "connection refused" errors
- Fix incorrect port in sweep-status skill

## Changes

- `CLAUDE.md` — clarify MLflow tracking section with port info
- `.claude/skills/sweep-status/SKILL.md` — fix port from 5001 to 5000

Co-Authored-By: Claude <noreply@anthropic.com>