### PR TITLE
fix(sweep_status): count k-fold runs as 1/k of a trial in ETA

### DIFF
--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -37,6 +37,11 @@ _DEFAULT_SAMPLE_SIZE = 100
 _DEFAULT_STALE_THRESHOLD_MIN = 20
 _DEFAULT_CONF_DIR = "conf/exp"
 
+# Dim file basenames excluded from node_clf sweep by scripts/design-dimension-sweep-all.sh.
+# Dims not in this set run under both design_spaces (graph_clf + node_clf), so their
+# expected trial count is doubled.
+_NODE_CLF_EXCLUDED_DIM_FILES = frozenset({"hpooling", "clusters", "global_pooling"})
+
 
 def _get_k_for_run(run) -> int:
     """Return the number of MLflow runs per trial for this run's dataset.
@@ -70,16 +75,24 @@ def _fmt_task_types(task_types: set) -> str:
     return "?"
 
 
-def load_expected_dims(conf_dir: str) -> dict[str, str]:
-    """Return {design_dimension: choices_str} from all conf/exp/*.yaml files."""
+def load_expected_dims(conf_dir: str) -> dict[str, dict]:
+    """Return {design_dimension: {choices: str, task_factor: int}} from conf/exp/*.yaml.
+
+    task_factor is 2 for dims launched under both design_spaces, 1 for graph-only dims.
+    """
     result = {}
     for path in glob.glob(os.path.join(conf_dir, "*.yaml")):
+        basename = Path(path).stem
         with open(path) as f:
             cfg = yaml.safe_load(f)
         dim = cfg.get("design_dimension")
         choices = cfg.get("design_choices", [])
         if dim:
-            result[dim] = "|".join(str(c) for c in choices)
+            task_factor = 1 if basename in _NODE_CLF_EXCLUDED_DIM_FILES else 2
+            result[dim] = {
+                "choices": "|".join(str(c) for c in choices),
+                "task_factor": task_factor,
+            }
     return result
 
 
@@ -171,7 +184,11 @@ def classify_dims(runs: list, stale_threshold_min: float, now_ms: float) -> dict
         num_choices = len(choices.split("|")) if choices != "?" else None
         avg_dur = sum(b["durations"]) / len(b["durations"]) if b["durations"] else None
         time_span_min = (b["max_end_ms"] - b["min_start_ms"]) / 60_000
-        total_runs = b["finished"] + b["failed"] + b["active"] + b["stale"]
+        done_trials = sum(
+            1.0 / _get_k_for_run(r)
+            for r in b["runs"]
+            if r.info.status in ("FINISHED", "FAILED")
+        )
         result[dim] = {
             "state": "STARTED",
             "task_types": b["task_types"],
@@ -181,7 +198,7 @@ def classify_dims(runs: list, stale_threshold_min: float, now_ms: float) -> dict
             "failed": b["failed"],
             "active": b["active"],
             "stale": b["stale"],
-            "total_runs": total_runs,
+            "done_trials": done_trials,
             "avg_dur_min": avg_dur,
             "cumul_min": sum(b["durations"]),
             "time_span_min": time_span_min,
@@ -201,15 +218,19 @@ def build_sweep_status_df(
     rows = []
 
     for dim, s in dim_stats.items():
-        trials = sample_size * s["num_choices"] if s["num_choices"] else None
+        task_str = _fmt_task_types(s["task_types"])
+        task_factor = 2 if task_str == "both" else 1
+        trials = (
+            sample_size * s["num_choices"] * task_factor if s["num_choices"] else None
+        )
         rows.append(
             {
                 "dimension": dim,
                 "state": s["state"],
-                "task": _fmt_task_types(s["task_types"]),
+                "task": task_str,
                 "choices": s["choices"],
                 "trials": trials,
-                "total_runs": s["total_runs"],
+                "done_trials": round(s["done_trials"], 1),
                 "finished": s["finished"],
                 "failed": s["failed"],
                 "active": s["active"],
@@ -222,17 +243,20 @@ def build_sweep_status_df(
 
     # Add PENDING rows for dims in conf/exp/ but not yet in MLflow
     seen_dims = set(dim_stats.keys())
-    for dim, choices_str in expected_dims.items():
+    for dim, info in expected_dims.items():
         if dim not in seen_dims:
+            choices_str = info["choices"]
             num_choices = len(choices_str.split("|")) if choices_str else None
+            task_factor = info["task_factor"]
+            trials = sample_size * num_choices * task_factor if num_choices else None
             rows.append(
                 {
                     "dimension": dim,
                     "state": "PENDING",
                     "task": "?",
                     "choices": choices_str,
-                    "trials": sample_size * num_choices if num_choices else None,
-                    "total_runs": 0,
+                    "trials": trials,
+                    "done_trials": 0.0,
                     "finished": 0,
                     "failed": 0,
                     "active": 0,
@@ -351,7 +375,7 @@ def print_summary(
             "task",
             "choices",
             "trials",
-            "total_runs",
+            "done_trials",
             "finished",
             "failed",
             "active",
@@ -373,10 +397,12 @@ def print_summary(
         print(sub[display_cols[state]].to_string(index=False))
 
     print(
-        "\nNote: trials = sample_size × num_choices (one k-fold CV job = 1 trial).\n"
-        "      Each k-fold MLflow run counts as 1/k of a trial in 'trials completed'.\n"
-        "      cumul_min = sum of individual run durations; "
-        "time_span_min = wall-clock span (first start to last end)."
+        "\nNote: trials = sample_size × num_choices × task_factor "
+        "(task_factor=2 for both-task dims, 1 for graph/node-only).\n"
+        "      done_trials = sum of 1/k per terminal run. "
+        "Each k-fold MLflow run counts as 1/k of a trial.\n"
+        "      cumul_min = sum of run durations; "
+        "time_span_min = wall-clock span."
     )
 
 

--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -21,13 +21,16 @@ import os
 import sys
 import time
 from collections import defaultdict
+from pathlib import Path
 
 import mlflow
 import pandas as pd
 import yaml
 from mlflow.tracking import MlflowClient
 
-from stgym.config_schema import dataset_eval_mode
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from stgym.config_schema import dataset_eval_mode  # noqa: E402
 
 _DEFAULT_TRACKING_URI = "http://127.0.0.1:5000"
 _DEFAULT_SAMPLE_SIZE = 100

--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -27,10 +27,24 @@ import pandas as pd
 import yaml
 from mlflow.tracking import MlflowClient
 
+from stgym.config_schema import dataset_eval_mode
+
 _DEFAULT_TRACKING_URI = "http://127.0.0.1:5000"
 _DEFAULT_SAMPLE_SIZE = 100
 _DEFAULT_STALE_THRESHOLD_MIN = 20
 _DEFAULT_CONF_DIR = "conf/exp"
+
+
+def _get_k_for_run(run) -> int:
+    """Return the number of MLflow runs per trial for this run's dataset.
+
+    A trial is one sampled config from the design space. For datasets with
+    train/val/test split, k=1. For k-fold CV datasets, k=num_folds.
+    """
+    name = run.data.tags.get("dataset_name")
+    if name and name in dataset_eval_mode:
+        return dataset_eval_mode[name].num_folds
+    return 1
 
 
 def _get_choices(runs: list) -> str:
@@ -67,7 +81,12 @@ def load_expected_dims(conf_dir: str) -> dict[str, str]:
 
 
 def compute_exp_stats(runs: list, now_ms: float) -> dict:
-    """Compute experiment-level timing and throughput statistics."""
+    """Compute experiment-level timing and throughput statistics.
+
+    Throughput and completed counts are reported in trial units, where each
+    k-fold MLflow run contributes 1/k to a trial. Run-count fields
+    (total_finished, total_failed) are kept for context.
+    """
     terminal = [r for r in runs if r.info.status in ("FINISHED", "FAILED")]
     finished = [r for r in runs if r.info.status == "FINISHED"]
     failed = [r for r in runs if r.info.status == "FAILED"]
@@ -77,6 +96,11 @@ def compute_exp_stats(runs: list, now_ms: float) -> dict:
 
     exp_start_ms = min(r.info.start_time for r in runs)
     exp_duration_h = (now_ms - exp_start_ms) / 3_600_000
+
+    total_completed_trials = sum(1.0 / _get_k_for_run(r) for r in terminal)
+    throughput_trials_per_h = (
+        total_completed_trials / exp_duration_h if exp_duration_h > 0 else 0
+    )
 
     def _completed_in_last(hours: float) -> int:
         cutoff_ms = now_ms - hours * 3_600_000
@@ -89,7 +113,8 @@ def compute_exp_stats(runs: list, now_ms: float) -> dict:
         "exp_duration_h": exp_duration_h,
         "total_finished": len(finished),
         "total_failed": len(failed),
-        "throughput_per_h": len(finished) / exp_duration_h if exp_duration_h > 0 else 0,
+        "total_completed_trials": total_completed_trials,
+        "throughput_trials_per_h": throughput_trials_per_h,
         "completed_2h": _completed_in_last(2),
         "completed_12h": _completed_in_last(12),
         "completed_24h": _completed_in_last(24),
@@ -222,37 +247,41 @@ def build_sweep_status_df(
 
 
 def compute_overall_progress(df: pd.DataFrame, exp_stats: dict) -> dict:
-    """Aggregate progress across all dimensions and compute ETA."""
+    """Aggregate progress across all dimensions and compute ETA.
+
+    Both total_completed_trials and total_expected are in trial units, so
+    k-fold over-runs do not mask remaining work in PENDING dimensions.
+    """
     total_finished = exp_stats.get("total_finished", 0)
     total_failed = exp_stats.get("total_failed", 0)
-    total_completed = total_finished + total_failed
+    total_completed_trials = exp_stats.get("total_completed_trials", 0.0)
     total_active = int(df["active"].sum())
     total_stale = int(df["stale"].sum())
 
     trials = df["trials"].dropna()
     total_expected = int(trials.sum()) if not trials.empty else None
 
-    throughput_per_h = exp_stats.get("throughput_per_h", 0)
-    throughput_per_min = throughput_per_h / 60
+    throughput_trials_per_h = exp_stats.get("throughput_trials_per_h", 0)
+    throughput_trials_per_min = throughput_trials_per_h / 60
 
     if (
         total_expected is not None
-        and throughput_per_min > 0
-        and total_completed < total_expected
+        and throughput_trials_per_min > 0
+        and total_completed_trials < total_expected
     ):
-        remaining = total_expected - total_completed
-        eta_min = remaining / throughput_per_min
+        remaining = total_expected - total_completed_trials
+        eta_min = remaining / throughput_trials_per_min
     else:
         eta_min = None
 
     return {
-        "total_completed": total_completed,
+        "total_completed_trials": total_completed_trials,
         "total_finished": total_finished,
         "total_failed": total_failed,
         "total_active": total_active,
         "total_stale": total_stale,
         "total_expected": total_expected,
-        "throughput_per_min": throughput_per_min,
+        "throughput_trials_per_min": throughput_trials_per_min,
         "eta_min": eta_min,
     }
 
@@ -281,19 +310,19 @@ def print_summary(
             else "?"
         )
         pct_str = (
-            f" ({100 * overall['total_completed'] / overall['total_expected']:.1f}%)"
+            f" ({100 * overall['total_completed_trials'] / overall['total_expected']:.1f}%)"
             if overall["total_expected"]
             else ""
         )
         print(
-            f"\nOverall    : {overall['total_completed']}/{total_expected_str}{pct_str} completed"
-            f" ({overall['total_finished']} success, {overall['total_failed']} failed),"
+            f"\nOverall    : {overall['total_completed_trials']:.1f}/{total_expected_str}{pct_str} trials completed"
+            f" (runs: {overall['total_finished']} success, {overall['total_failed']} failed),"
             f" {overall['total_active']} running, {overall['total_stale']} stale"
         )
         if overall["eta_min"] is not None:
             print(
                 f"ETA        : ~{overall['eta_min'] / 60:.1f} h"
-                f" (throughput: {overall['throughput_per_min']:.1f} runs/min)"
+                f" (throughput: {overall['throughput_trials_per_min']:.2f} trials/min)"
             )
         else:
             print("ETA        : N/A")
@@ -342,6 +371,7 @@ def print_summary(
 
     print(
         "\nNote: trials = sample_size × num_choices (one k-fold CV job = 1 trial).\n"
+        "      Each k-fold MLflow run counts as 1/k of a trial in 'trials completed'.\n"
         "      cumul_min = sum of individual run durations; "
         "time_span_min = wall-clock span (first start to last end)."
     )

--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -340,7 +340,7 @@ def print_summary(
             f"Finished    : {exp_stats['total_finished']} ok"
             f"  /  {exp_stats['total_failed']} failed"
         )
-        print(f"Throughput  : ~{exp_stats['throughput_per_h']:.1f} runs/h")
+        print(f"Throughput  : ~{exp_stats['throughput_trials_per_h']:.1f} trials/h")
         print(f"\nCompleted last  2 h : {exp_stats['completed_2h']:>5}")
         print(f"Completed last 12 h : {exp_stats['completed_12h']:>5}")
         print(f"Completed last 24 h : {exp_stats['completed_24h']:>5}")

--- a/scripts/sweep_status.py
+++ b/scripts/sweep_status.py
@@ -320,14 +320,23 @@ def print_summary(
     sample_size: int,
     exp_stats: dict,
 ):
-    n_started = (df["state"] == "STARTED").sum()
+    started_df = df[df["state"] == "STARTED"]
+    n_started = len(started_df)
     n_pending = (df["state"] == "PENDING").sum()
+    n_completed = (
+        (started_df["done_trials"] >= started_df["trials"]).sum()
+        if not started_df.empty
+        else 0
+    )
+    n_in_progress = n_started - n_completed
     sep = "=" * 80
 
     print(f"\nExperiment : {exp_name}")
     print(f"ID         : {exp_id}")
     print(f"Sample size: {sample_size} groups/dimension")
-    print(f"Dimensions : {n_started} started, {n_pending} pending")
+    print(
+        f"Dimensions : {n_completed} completed, {n_in_progress} in-progress, {n_pending} pending"
+    )
 
     if exp_stats:
         overall = compute_overall_progress(df, exp_stats)

--- a/tests/mock_mlflow.py
+++ b/tests/mock_mlflow.py
@@ -17,6 +17,8 @@ class MockRunInfo:
     """Mock MLflow run info structure for testing."""
 
     status: str = "FINISHED"
+    start_time: int = 0
+    end_time: int | None = None
 
 
 @dataclass

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -6,9 +6,116 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.mock_mlflow import MockRun, MockRunData, MockRunInfo
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from sweep_status import compute_overall_progress  # noqa: E402
+from sweep_status import (  # noqa: E402
+    _get_k_for_run,
+    compute_exp_stats,
+    compute_overall_progress,
+)
+
+
+def _mock_run(
+    status: str,
+    start_time: int = 0,
+    end_time: int | None = None,
+    dataset_name: str | None = None,
+) -> MockRun:
+    tags = {"dataset_name": dataset_name} if dataset_name is not None else {}
+    return MockRun(
+        data=MockRunData(tags=tags),
+        info=MockRunInfo(status=status, start_time=start_time, end_time=end_time),
+    )
+
+
+class TestGetKForRun:
+    """Tests for _get_k_for_run helper."""
+
+    @pytest.mark.parametrize(
+        "dataset_name, expected_k",
+        [
+            ("human-intestine", 8),
+            ("spatial-vdj", 5),
+            ("human-pancreas", 3),
+            ("colorectal-cancer", 4),
+            ("gastric-bladder-cancer", 3),
+            ("cellcontrast-breast", 5),
+        ],
+    )
+    def test_kfold_dataset_returns_num_folds(
+        self, dataset_name: str, expected_k: int
+    ) -> None:
+        run = _mock_run("FINISHED", dataset_name=dataset_name)
+        assert _get_k_for_run(run) == expected_k
+
+    def test_non_kfold_dataset_returns_one(self) -> None:
+        run = _mock_run("FINISHED", dataset_name="brca")
+        assert _get_k_for_run(run) == 1
+
+    def test_missing_dataset_tag_returns_one(self) -> None:
+        run = _mock_run("FINISHED")
+        assert _get_k_for_run(run) == 1
+
+
+class TestComputeExpStats:
+    """Tests for compute_exp_stats."""
+
+    def test_empty_runs_returns_empty(self) -> None:
+        assert compute_exp_stats([], now_ms=10_000) == {}
+
+    def test_non_kfold_runs_count_one_per_trial(self) -> None:
+        runs = [
+            _mock_run("FINISHED", start_time=0, end_time=1_000, dataset_name="brca"),
+            _mock_run("FINISHED", start_time=0, end_time=1_000, dataset_name="brca"),
+            _mock_run("FAILED", start_time=0, end_time=1_000, dataset_name="brca"),
+        ]
+        # Total duration: 1 hour
+        stats = compute_exp_stats(runs, now_ms=3_600_000)
+
+        assert stats["total_finished"] == 2
+        assert stats["total_failed"] == 1
+        assert stats["total_completed_trials"] == pytest.approx(3.0)
+        assert stats["throughput_trials_per_h"] == pytest.approx(3.0)
+
+    def test_kfold_runs_contribute_fractionally(self) -> None:
+        # 5-fold dataset: 5 finished runs == 1 trial
+        runs = [
+            _mock_run(
+                "FINISHED",
+                start_time=0,
+                end_time=1_000,
+                dataset_name="spatial-vdj",
+            )
+            for _ in range(5)
+        ]
+        stats = compute_exp_stats(runs, now_ms=3_600_000)
+
+        assert stats["total_finished"] == 5
+        assert stats["total_completed_trials"] == pytest.approx(1.0)
+        assert stats["throughput_trials_per_h"] == pytest.approx(1.0)
+
+    def test_mixed_kfold_and_non_kfold(self) -> None:
+        # 5 fold runs (spatial-vdj, k=5) + 2 non-fold runs (brca, k=1)
+        # = 1 trial + 2 trials = 3 completed trials
+        runs = [
+            _mock_run(
+                "FINISHED",
+                start_time=0,
+                end_time=1_000,
+                dataset_name="spatial-vdj",
+            )
+            for _ in range(5)
+        ] + [
+            _mock_run("FINISHED", start_time=0, end_time=1_000, dataset_name="brca"),
+            _mock_run("FAILED", start_time=0, end_time=1_000, dataset_name="brca"),
+        ]
+        stats = compute_exp_stats(runs, now_ms=3_600_000)
+
+        assert stats["total_finished"] == 6
+        assert stats["total_failed"] == 1
+        assert stats["total_completed_trials"] == pytest.approx(3.0)
 
 
 class TestComputeOverallProgress:
@@ -30,34 +137,35 @@ class TestComputeOverallProgress:
         return {
             "total_finished": 38,
             "total_failed": 4,
-            "throughput_per_h": 12.0,
+            "total_completed_trials": 42.0,
+            "throughput_trials_per_h": 12.0,
         }
 
     def test_normal_case(self) -> None:
         result = compute_overall_progress(self.base_df, self.base_exp_stats)
 
-        assert result["total_completed"] == 42
+        assert result["total_completed_trials"] == pytest.approx(42.0)
         assert result["total_finished"] == 38
         assert result["total_failed"] == 4
         assert result["total_active"] == 3
         assert result["total_stale"] == 1
         assert result["total_expected"] == 100
-        assert result["throughput_per_min"] == pytest.approx(0.2)
-        # remaining = 100 - 42 = 58, throughput = 0.2 runs/min → eta = 290 min
+        assert result["throughput_trials_per_min"] == pytest.approx(0.2)
+        # remaining = 100 - 42 = 58, throughput = 0.2 trials/min → eta = 290 min
         assert result["eta_min"] == pytest.approx(290.0)
 
     def test_zero_throughput_gives_no_eta(self) -> None:
-        exp_stats = {**self.base_exp_stats, "throughput_per_h": 0.0}
+        exp_stats = {**self.base_exp_stats, "throughput_trials_per_h": 0.0}
         result = compute_overall_progress(self.base_df, exp_stats)
 
         assert result["eta_min"] is None
-        assert result["throughput_per_min"] == pytest.approx(0.0)
+        assert result["throughput_trials_per_min"] == pytest.approx(0.0)
 
-    def test_all_runs_completed_gives_no_eta(self) -> None:
-        exp_stats = {**self.base_exp_stats, "total_finished": 100, "total_failed": 0}
+    def test_all_trials_completed_gives_no_eta(self) -> None:
+        exp_stats = {**self.base_exp_stats, "total_completed_trials": 100.0}
         result = compute_overall_progress(self.base_df, exp_stats)
 
-        assert result["total_completed"] == 100
+        assert result["total_completed_trials"] == pytest.approx(100.0)
         assert result["total_expected"] == 100
         assert result["eta_min"] is None
 
@@ -85,3 +193,34 @@ class TestComputeOverallProgress:
         result = compute_overall_progress(df, self.base_exp_stats)
 
         assert result["total_expected"] == expected_total
+
+    def test_pending_dim_with_overrun_kfold_still_yields_eta(self) -> None:
+        # Reproduces the bug from issue #186:
+        # k-fold dim has more runs than trials, but a PENDING dim has 0 runs.
+        # In trial units, total_completed_trials < total_expected, so ETA is computed.
+        df = pd.DataFrame(
+            {
+                "active": [0, 0],
+                "stale": [0, 0],
+                "trials": [50.0, 50.0],
+                "state": ["STARTED", "PENDING"],
+            }
+        )
+        # STARTED dim has 50 trials worth of finished k-fold runs;
+        # PENDING dim contributes 0 completed trials.
+        exp_stats = {
+            "total_finished": 250,  # 50 trials × 5 folds
+            "total_failed": 0,
+            "total_completed_trials": 50.0,
+            "throughput_trials_per_h": 6.0,
+        }
+        result = compute_overall_progress(df, exp_stats)
+
+        assert result["total_expected"] == 100
+        assert result["total_completed_trials"] == pytest.approx(50.0)
+        # Percentage stays at 50%, not over 100% as in the bug.
+        assert 100 * result["total_completed_trials"] / result[
+            "total_expected"
+        ] == pytest.approx(50.0)
+        # ETA is computed (not None): remaining = 50, throughput = 0.1 trials/min
+        assert result["eta_min"] == pytest.approx(500.0)

--- a/tests/test_sweep_status.py
+++ b/tests/test_sweep_status.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from sweep_status import (  # noqa: E402
     _get_k_for_run,
+    build_sweep_status_df,
     compute_exp_stats,
     compute_overall_progress,
 )
@@ -224,3 +225,79 @@ class TestComputeOverallProgress:
         ] == pytest.approx(50.0)
         # ETA is computed (not None): remaining = 50, throughput = 0.1 trials/min
         assert result["eta_min"] == pytest.approx(500.0)
+
+
+class TestBuildSweepStatusDf:
+    """Tests for build_sweep_status_df task_factor and done_trials."""
+
+    def test_both_task_dim_doubles_trials(self) -> None:
+        dim_stats = {
+            "model.dim_inner": {
+                "state": "STARTED",
+                "task_types": {"graph-classification", "node-classification"},
+                "choices": "16|32|64",
+                "num_choices": 3,
+                "finished": 10,
+                "failed": 2,
+                "active": 0,
+                "stale": 0,
+                "done_trials": 12.0,
+                "avg_dur_min": 2.0,
+                "cumul_min": 24.0,
+                "time_span_min": 100.0,
+            }
+        }
+        expected_dims: dict = {}
+        df = build_sweep_status_df(
+            dim_stats, sample_size=100, expected_dims=expected_dims
+        )
+
+        row = df.iloc[0]
+        assert row["task"] == "both"
+        assert row["trials"] == 600  # 100 * 3 * 2
+        assert row["done_trials"] == 12.0
+
+    def test_single_task_dim_no_multiplier(self) -> None:
+        dim_stats = {
+            "model.global_pooling": {
+                "state": "STARTED",
+                "task_types": {"graph-classification"},
+                "choices": "mean|max|add",
+                "num_choices": 3,
+                "finished": 6,
+                "failed": 0,
+                "active": 0,
+                "stale": 0,
+                "done_trials": 6.0,
+                "avg_dur_min": 3.0,
+                "cumul_min": 18.0,
+                "time_span_min": 50.0,
+            }
+        }
+        expected_dims: dict = {}
+        df = build_sweep_status_df(
+            dim_stats, sample_size=100, expected_dims=expected_dims
+        )
+
+        row = df.iloc[0]
+        assert row["task"] == "graph-clf"
+        assert row["trials"] == 300  # 100 * 3 * 1
+        assert row["done_trials"] == 6.0
+
+    def test_pending_dim_uses_expected_task_factor(self) -> None:
+        dim_stats: dict = {}
+        expected_dims = {
+            "model.act": {"choices": "relu|prelu", "task_factor": 2},
+            "model.pooling.type": {"choices": "dmon|mincut", "task_factor": 1},
+        }
+        df = build_sweep_status_df(
+            dim_stats, sample_size=100, expected_dims=expected_dims
+        )
+
+        df = df.sort_values("dimension").reset_index(drop=True)
+        assert df.iloc[0]["dimension"] == "model.act"
+        assert df.iloc[0]["trials"] == 400  # 100 * 2 * 2
+        assert df.iloc[0]["done_trials"] == 0.0
+
+        assert df.iloc[1]["dimension"] == "model.pooling.type"
+        assert df.iloc[1]["trials"] == 200  # 100 * 2 * 1


### PR DESCRIPTION
## Problem

`compute_overall_progress()` showed misleading percentages and premature ETA: N/A due to two unit mismatches:

1. **K-fold over-counting**: `total_completed` counted MLflow runs (inflated k× by k-fold CV — one trial = k runs), while `total_expected` counted trials. Whenever a k-fold dimension over-ran, `total_completed > total_expected` masked remaining PENDING work.

2. **Both-task multiplier missing**: Dims launched for both `graph_clf` and `node_clf` design spaces produce 2× the trials of single-task dims, but `total_expected` didn't account for this.

Reported case: `Overall: 18168/5100 (356.2%)` instead of `9000/9000 (100.0%)`.

Fixes #186

## Solution

Normalize both sides to **trial units**:

1. Each k-fold MLflow run contributes `1/k` to a completed trial, where `k` is looked up via the run's `dataset_name` tag from `dataset_eval_mode` in `stgym/config_schema.py`.

2. Expected trials per dim = `sample_size × num_choices × task_factor`, where `task_factor` is 2 for both-task dims and 1 for single-task dims (determined by file basename matching `_NODE_CLF_EXCLUDED_DIM_FILES`).

3. Per-dim table now shows `done_trials` (trial units) instead of `total_runs` (run counts) to avoid mixing units.

## Changes

- `scripts/sweep_status.py`:
  - `_get_k_for_run(run)` — returns `num_folds` for k-fold datasets, else 1
  - `_NODE_CLF_EXCLUDED_DIM_FILES` — dims excluded from node_clf sweep (graph-only)
  - `load_expected_dims()` — returns `{dim: {choices, task_factor}}`
  - `classify_dims()` — adds `done_trials` per dim
  - `build_sweep_status_df()` — applies task_factor, replaces `total_runs` with `done_trials`
  - `compute_exp_stats()` / `compute_overall_progress()` — trial-unit metrics
  - `print_summary()` — updated display columns and Note footer

- `tests/mock_mlflow.py` — `MockRunInfo` gains optional `start_time` / `end_time`

- `tests/test_sweep_status.py` — tests for `_get_k_for_run`, `compute_exp_stats`, `build_sweep_status_df` task_factor/done_trials, and regression test for PENDING + over-run k-fold case

## Testing

- [x] `pre-commit run --files scripts/sweep_status.py tests/test_sweep_status.py tests/mock_mlflow.py` passes
- [x] `pytest tests/ -m 'not slow'` — all pass
- [x] Verified on cyy2 exp 12: `Overall: 9000.0/9000 (100.0%)` (was 18168/5100)

Co-Authored-By: Claude <noreply@anthropic.com>