### PR TITLE
fix(sandbox): register missing plugin marketplaces for Docker environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,5 @@ ACTIVITY.log
 # OpenTelemetry logs from the sandbox — may contain bash commands with
 # inlined env vars; never commit.
 sandbox/telemetry/
+
+wiki/raw/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Ad-hoc single-run configs (for debugging, repro) live in `conf/adhoc/`.
 ```bash
 uv sync --group dev       # install all dependencies including dev tools
 source .venv/bin/activate # activate venv
+bash scripts/setup-sandbox-plugins.sh  # register plugin marketplaces (idempotent)
 ```
 
 > **Important — always activate `.venv` before `git commit`.** `pre-commit`, `ruff`, and `ty` all live inside `.venv`. Non-login shells (including fresh agent shells) do **not** inherit it, and commits will fail with `pre-commit not found`. Chain the activation in the same command:

--- a/sandbox/entrypoint.sh
+++ b/sandbox/entrypoint.sh
@@ -8,6 +8,8 @@ echo "Installing dependencies..."
 uv sync --group dev --reinstall
 echo "Installing pre-commit hooks..."
 pre-commit install --install-hooks
+echo "Setting up Claude Code plugins..."
+bash /repo/scripts/setup-sandbox-plugins.sh || echo "Plugin setup failed — run scripts/setup-sandbox-plugins.sh manually to retry."
 echo "Ready."
 
 exec bash

--- a/scripts/setup-sandbox-plugins.sh
+++ b/scripts/setup-sandbox-plugins.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Registers project-required plugin marketplaces in the local Claude Code installation.
+# Run once after setting up a fresh sandbox/Docker environment.
+set -euo pipefail
+
+MARKETPLACES_FILE="${HOME}/.claude/plugins/known_marketplaces.json"
+
+if [ ! -f "$MARKETPLACES_FILE" ]; then
+  echo "known_marketplaces.json not found at $MARKETPLACES_FILE — is Claude Code installed?"
+  exit 1
+fi
+
+python3 - <<'EOF'
+import json, os, sys
+from datetime import datetime, timezone
+
+path = os.path.expanduser("~/.claude/plugins/known_marketplaces.json")
+with open(path) as f:
+    data = json.load(f)
+
+now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+plugins_dir = os.path.expanduser("~/.claude/plugins/marketplaces")
+
+required = {
+    "marimo-pair": {
+        "source": {"source": "github", "repo": "marimo-team/marimo-pair"},
+        "installLocation": f"{plugins_dir}/marimo-pair",
+        "lastUpdated": now,
+        "autoUpdate": True,
+    },
+    "context7-marketplace": {
+        "source": {"source": "github", "repo": "upstash/context7"},
+        "installLocation": f"{plugins_dir}/context7-marketplace",
+        "lastUpdated": now,
+    },
+    "wiki-skills": {
+        "source": {"source": "github", "repo": "xiaohan2012/wiki-skills"},
+        "installLocation": f"{plugins_dir}/wiki-skills",
+        "lastUpdated": now,
+    },
+}
+
+added = []
+for name, entry in required.items():
+    if name not in data:
+        data[name] = entry
+        added.append(name)
+
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+
+if added:
+    print(f"Registered marketplaces: {', '.join(added)}")
+else:
+    print("All marketplaces already registered.")
+EOF

--- a/scripts/setup-sandbox-plugins.sh
+++ b/scripts/setup-sandbox-plugins.sh
@@ -1,17 +1,30 @@
 #!/usr/bin/env bash
-# Registers project-required plugin marketplaces in the local Claude Code installation.
-# Run once after setting up a fresh sandbox/Docker environment.
+# Registers project-required plugin marketplaces and installs plugins.
+# Idempotent — safe to run multiple times.
 set -euo pipefail
 
-MARKETPLACES_FILE="${HOME}/.claude/plugins/known_marketplaces.json"
+PLUGINS_DIR="${HOME}/.claude/plugins"
+MARKETPLACES_FILE="${PLUGINS_DIR}/known_marketplaces.json"
 
+# Bootstrap known_marketplaces.json if Claude hasn't been initialised yet
 if [ ! -f "$MARKETPLACES_FILE" ]; then
-  echo "known_marketplaces.json not found at $MARKETPLACES_FILE — is Claude Code installed?"
-  exit 1
+  mkdir -p "$PLUGINS_DIR"
+  NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+  cat > "$MARKETPLACES_FILE" <<JSON
+{
+  "claude-plugins-official": {
+    "source": {"source": "github", "repo": "anthropics/claude-plugins-official"},
+    "installLocation": "${PLUGINS_DIR}/marketplaces/claude-plugins-official",
+    "lastUpdated": "${NOW}"
+  }
+}
+JSON
+  echo "Initialised ${MARKETPLACES_FILE}"
 fi
 
+# Register any missing marketplaces
 python3 - <<'EOF'
-import json, os, sys
+import json, os
 from datetime import datetime, timezone
 
 path = os.path.expanduser("~/.claude/plugins/known_marketplaces.json")
@@ -55,3 +68,17 @@ if added:
 else:
     print("All marketplaces already registered.")
 EOF
+
+# Install plugins (project scope, idempotent — failures are non-fatal)
+install_plugin() {
+  local plugin="$1"
+  if claude plugins install "$plugin" --scope project 2>/dev/null; then
+    echo "Installed plugin: $plugin"
+  else
+    echo "Plugin already installed or unavailable: $plugin"
+  fi
+}
+
+install_plugin "marimo-pair@marimo-pair"
+install_plugin "context7-plugin@context7-marketplace"
+install_plugin "wiki-skills@wiki-skills"


### PR DESCRIPTION
## Summary

- Fresh Docker sandbox environments only have `claude-plugins-official` registered in `~/.claude/plugins/known_marketplaces.json`, causing 3 plugin errors for `marimo-pair`, `context7-marketplace`, and `wiki-skills`
- Adds `scripts/setup-sandbox-plugins.sh` — an idempotent script that registers all project-required marketplaces
- Documents the script in CLAUDE.md under the Environment setup section

## Test plan

- [x] Spin up a fresh Docker sandbox
- [x] Run `bash scripts/setup-sandbox-plugins.sh`
- [x] Open Claude Code and verify the Plugins → Errors tab shows no errors for the three marketplaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)