### PR TITLE
feat(task-repr): task representation via anchor-model fingerprinting

### DIFF
--- a/conf/task_repr/graph_clf.yaml
+++ b/conf/task_repr/graph_clf.yaml
@@ -1,0 +1,44 @@
+task_type: graph-classification
+datasets:
+  - brca
+  - spatial-vdj
+  - glioblastoma
+  - brca-grade
+  - gastric-bladder-cancer
+  - mouse-kidney
+  - inflammatory-skin
+  - mouse-preoptic
+  - brca-ptnm-m
+
+design_space:
+  model:
+    num_mp_layers: 1
+    global_pooling: ['mean', 'max']
+    normalize_adj: [false, true]
+    layer_type: ["gcnconv", "ginconv", "sageconv"]
+    dim_inner: [16, 32, 64, 128]
+    act: ['prelu', 'relu', 'swish']
+    use_batchnorm: [true, false]
+    pooling:
+      type:
+        - dmon
+        - mincut
+      n_clusters: [10, 20]
+    post_mp_dims:
+      - '16'
+      - '32'
+      - '64'
+      - '64,32'
+      - '32, 16'
+  train:
+    optim:
+      optimizer: ['adam', 'sgd']
+      base_lr: [0.1, 0.01, 0.001]
+    lr_schedule:
+      type: null
+    max_epoch: [100, 200, 300]
+  data_loader:
+    graph_const: ['knn', 'radius']
+    knn_k: [10, 20, 30]
+    radius_ratio: [0.05, 0.075, 0.1]
+    batch_size: [4, 8, 16, 32]

--- a/conf/task_repr/node_clf.yaml
+++ b/conf/task_repr/node_clf.yaml
@@ -1,0 +1,41 @@
+task_type: node-classification
+datasets:
+  - breast-cancer
+  - human-intestine
+  - colorectal-cancer
+  - upmc
+  - charville
+  - mouse-spleen
+  - human-crc
+  - human-pancreas
+  - human-lung
+  - cellcontrast-breast
+
+design_space:
+  model:
+    num_mp_layers: 1
+    global_pooling: null
+    normalize_adj: [false, true]
+    layer_type: ["gcnconv", "ginconv", "sageconv"]
+    dim_inner: [16, 32, 64, 128]
+    act: ['prelu', 'relu', 'swish']
+    use_batchnorm: [true, false]
+    pooling: null
+    post_mp_dims:
+      - '16'
+      - '32'
+      - '64'
+      - '64,32'
+      - '32, 16'
+  train:
+    optim:
+      optimizer: ['adam', 'sgd']
+      base_lr: [0.1, 0.01, 0.001]
+    lr_schedule:
+      type: null
+    max_epoch: [100, 200, 300]
+  data_loader:
+    graph_const: ['knn', 'radius']
+    knn_k: [10, 20, 30]
+    radius_ratio: [0.05, 0.075, 0.1]
+    batch_size: [4, 8, 16, 32]

--- a/conf/task_repr_config.yaml
+++ b/conf/task_repr_config.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - task_repr: node_clf
+  - resource: cpu-4
+  - mlflow: local
+  - _self_
+
+n_designs: 96
+n_anchors: 12
+random_seed: 42
+
+gated_datasets:
+  - mouse-kidney
+  - breast-cancer

--- a/run_task_repr.py
+++ b/run_task_repr.py
@@ -1,0 +1,79 @@
+import os
+
+os.environ["PYTORCH_NO_CUDA_MEMORY_CACHING"] = "1"
+
+import hydra
+import ray
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from stgym.config_schema import MLFlowConfig, ResourceConfig
+from stgym.design_space.schema import TaskReprDesignSpace
+from stgym.rct import run_exp
+from stgym.task_repr import make_exp_config, sample_designs
+from stgym.utils import DatasetLoadGate, RayProgressBar, create_mlflow_experiment
+
+
+@hydra.main(config_path="./conf", config_name="task_repr_config", version_base=None)
+def main(cfg: DictConfig):
+    print(OmegaConf.to_yaml(cfg))
+
+    space = TaskReprDesignSpace.model_validate(
+        OmegaConf.to_container(cfg.task_repr.design_space, resolve=True)
+    )
+    task_type: str = cfg.task_repr.task_type
+    datasets: list[str] = list(cfg.task_repr.datasets)
+
+    res_cfg = ResourceConfig(**cfg.resource)
+    mlflow_cfg = MLFlowConfig(**cfg.mlflow)
+
+    if res_cfg.omp_num_threads is not None:
+        os.environ["OMP_NUM_THREADS"] = str(res_cfg.omp_num_threads)
+        torch.set_num_threads(res_cfg.omp_num_threads)
+
+    create_mlflow_experiment(mlflow_cfg.experiment_name)
+
+    if not ray.is_initialized():
+        ray.init(num_cpus=res_cfg.num_cpus, num_gpus=res_cfg.num_gpus)
+
+    gated_datasets = frozenset(cfg.gated_datasets)
+    if gated_datasets:
+        DatasetLoadGate.options(name="dataset_load_gate").remote(max_concurrent=1)
+
+    designs = sample_designs(space, task_type, n=cfg.n_designs, seed=cfg.random_seed)
+
+    promises = []
+    for dataset_name in datasets:
+        for design_id, partial in designs:
+            exp_cfg = make_exp_config(partial, dataset_name)
+
+            run_exp_remote = ray.remote(
+                num_cpus=res_cfg.num_cpus_per_trial,
+                num_gpus=res_cfg.num_gpus_per_trial,
+                max_calls=1,
+            )(run_exp)
+            promises.append(
+                run_exp_remote.remote(
+                    exp_cfg,
+                    mlflow_cfg,
+                    metadata_for_tag={
+                        "design_id": str(design_id),
+                        "task_repr_sweep": "true",
+                    },
+                )
+            )
+
+    total = len(promises)
+    print(
+        f"Total experiments: {total} ({cfg.n_designs} designs × {len(datasets)} tasks)"
+    )
+
+    if promises:
+        RayProgressBar.show(promises)
+        ray.get(promises)
+
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/stgym/design_space/schema.py
+++ b/stgym/design_space/schema.py
@@ -85,3 +85,14 @@ class DesignSpace(ModelWithZip, YamlLoaderMixin):
     train: TrainSpace
     task: TaskSpace
     data_loader: DataLoaderSpace
+
+
+class TaskReprDesignSpace(ModelWithZip, YamlLoaderMixin):
+    """Design space for task representation sweeps — no task field.
+
+    task_type and datasets are provided separately in the Hydra config.
+    """
+
+    model: ModelSpace
+    train: TrainSpace
+    data_loader: DataLoaderSpace

--- a/stgym/task_repr.py
+++ b/stgym/task_repr.py
@@ -1,0 +1,232 @@
+"""Task representation via anchor-model performance fingerprinting.
+
+Pipeline:
+  1. sample_designs        — sample D task-free configs from a TaskReprDesignSpace
+  2. (run experiments)     — run_task_repr.py dispatches D×T Ray tasks, tags each with design_id
+  3. build_performance_matrix — pivot MLflow runs into a design_id × dataset DataFrame
+  4. select_anchor_models  — bin designs by avg score, pick median per bin
+  5. compute_fingerprints  — subset matrix to anchor rows, transpose to task × anchor
+  6. pairwise_similarity   — Kendall tau between every pair of task fingerprint vectors
+"""
+
+import hashlib
+import json
+
+import numpy as np
+import pandas as pd
+from scipy.stats import kendalltau
+
+from stgym.config_schema import (
+    ExperimentConfig,
+    TaskConfig,
+)
+from stgym.data_loader.ds_info import get_info
+from stgym.design_space.design_gen import (
+    generate_data_loader_config,
+    generate_model_config,
+    generate_train_config,
+)
+from stgym.design_space.schema import TaskReprDesignSpace
+from stgym.utils import rand_ints
+
+
+def sample_designs(
+    space: TaskReprDesignSpace,
+    task_type: str,
+    n: int,
+    seed: int = 42,
+) -> list[tuple[int, dict]]:
+    """Sample n task-free design configs from a TaskReprDesignSpace.
+
+    Returns a list of (design_id, partial_config_dict) where partial_config_dict
+    contains model, train, and data_loader keys but no task. design_id is a
+    stable integer index 0..n-1.
+    """
+    seeds = rand_ints(n, seed=seed)
+    model_cfgs = generate_model_config(task_type, space.model, k=n, seed=seed)
+    train_cfgs = generate_train_config(space.train, k=n, seed=seed)
+    dl_cfgs = generate_data_loader_config(space.data_loader, k=n, seed=seed)
+
+    return [
+        (i, {"model": model_cfgs[i], "train": train_cfgs[i], "data_loader": dl_cfgs[i]})
+        for i in range(n)
+    ]
+
+
+def make_exp_config(
+    partial: dict,
+    dataset_name: str,
+) -> ExperimentConfig:
+    """Attach a task to a partial design config to produce a full ExperimentConfig."""
+    ds_info = get_info(dataset_name)
+    task_cfg = TaskConfig(
+        dataset_name=dataset_name,
+        type=ds_info["task_type"],
+        num_classes=ds_info["num_classes"],
+    )
+    return ExperimentConfig(
+        model=partial["model"],
+        train=partial["train"],
+        data_loader=partial["data_loader"],
+        task=task_cfg,
+    )
+
+
+def build_performance_matrix(
+    runs: list,
+    metric_name: str,
+    min_task_coverage: float = 0.5,
+) -> pd.DataFrame:
+    """Build a design_id × dataset performance matrix from MLflow runs.
+
+    Runs must have the 'design_id' tag set by run_task_repr.py. K-fold runs
+    are averaged per (design_id, dataset_name) before pivoting.
+
+    Args:
+        runs: list of mlflow.entities.Run objects.
+        metric_name: MLflow metric key to extract (e.g. 'test_roc_auc').
+        min_task_coverage: drop designs that cover fewer than this fraction of tasks.
+
+    Returns:
+        DataFrame with index=design_id (int), columns=dataset_name, values=mean metric.
+        Rows with insufficient task coverage are dropped.
+    """
+    rows = []
+    for r in runs:
+        design_id = r.data.tags.get("design_id")
+        dataset = r.data.tags.get("dataset_name")
+        fold = r.data.tags.get("fold")
+        metric = r.data.metrics.get(metric_name)
+        status = r.info.status
+        if design_id is None or dataset is None or metric is None:
+            continue
+        rows.append(
+            {
+                "design_id": int(design_id),
+                "dataset_name": dataset,
+                "fold": fold,
+                "metric": metric,
+                "run_status": status,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+
+    # aggregate k-fold folds: mean metric, FINISHED only if all folds finished
+    has_fold = df["fold"].notna()
+    kfold_df = df[has_fold]
+    non_kfold_df = df[~has_fold]
+
+    parts = [non_kfold_df[["design_id", "dataset_name", "metric", "run_status"]]]
+    if not kfold_df.empty:
+        kfold_agg = kfold_df.groupby(["design_id", "dataset_name"], as_index=False).agg(
+            metric=("metric", "mean"),
+            run_status=(
+                "run_status",
+                lambda x: "FINISHED" if (x == "FINISHED").all() else "FAILED",
+            ),
+        )
+        parts.append(kfold_agg)
+
+    df = pd.concat(parts, ignore_index=True)
+    df = df[df["run_status"] == "FINISHED"]
+
+    # average across any remaining duplicates (same design re-run on same task)
+    df = df.groupby(["design_id", "dataset_name"], as_index=False)["metric"].mean()
+
+    matrix = df.pivot(index="design_id", columns="dataset_name", values="metric")
+
+    n_tasks = matrix.shape[1]
+    coverage = matrix.notna().sum(axis=1) / n_tasks
+    matrix = matrix[coverage >= min_task_coverage]
+
+    return matrix
+
+
+def select_anchor_models(
+    matrix: pd.DataFrame,
+    n_anchors: int = 12,
+) -> list[int]:
+    """Select anchor models by binning designs on avg performance and taking medians.
+
+    Designs are ranked by their mean score across all tasks, split into
+    n_anchors equal-sized bins, and the design with the median score in each
+    bin is selected.
+
+    Args:
+        matrix: design_id × dataset DataFrame (from build_performance_matrix).
+        n_anchors: number of anchor models to select.
+
+    Returns:
+        List of design_id integers identifying the anchor models.
+    """
+    if len(matrix) < n_anchors:
+        raise ValueError(
+            f"Not enough designs ({len(matrix)}) to select {n_anchors} anchors."
+        )
+
+    avg_scores = matrix.mean(axis=1).sort_values()
+    design_ids = avg_scores.index.tolist()
+    bins = np.array_split(design_ids, n_anchors)
+
+    anchors = []
+    for bin_ids in bins:
+        bin_scores = avg_scores.loc[bin_ids]
+        median_idx = (bin_scores - bin_scores.median()).abs().idxmin()
+        anchors.append(int(median_idx))
+
+    return anchors
+
+
+def compute_fingerprints(
+    matrix: pd.DataFrame,
+    anchor_ids: list[int],
+) -> pd.DataFrame:
+    """Compute task fingerprints as anchor-model performance vectors.
+
+    Args:
+        matrix: design_id × dataset DataFrame.
+        anchor_ids: design_ids to use as anchor models.
+
+    Returns:
+        DataFrame with index=dataset_name, columns=anchor design_id,
+        values=performance score of that anchor on that task.
+    """
+    anchor_rows = matrix.loc[anchor_ids]
+    return anchor_rows.T
+
+
+def pairwise_similarity(fingerprints: pd.DataFrame) -> pd.DataFrame:
+    """Compute pairwise task similarity via Kendall rank correlation.
+
+    Args:
+        fingerprints: task × anchor_model DataFrame (from compute_fingerprints).
+
+    Returns:
+        Symmetric task × task DataFrame of Kendall tau correlation values.
+    """
+    tasks = fingerprints.index.tolist()
+    n = len(tasks)
+    sim = np.zeros((n, n))
+
+    for i in range(n):
+        for j in range(i, n):
+            tau, _ = kendalltau(fingerprints.iloc[i], fingerprints.iloc[j])
+            sim[i, j] = tau
+            sim[j, i] = tau
+
+    return pd.DataFrame(sim, index=tasks, columns=tasks)
+
+
+def design_hash(partial: dict) -> str:
+    """Stable hex digest of a partial design config (model + train + data_loader)."""
+    serialisable = {
+        "model": partial["model"].model_dump(),
+        "train": partial["train"].model_dump(),
+        "data_loader": partial["data_loader"].model_dump(),
+    }
+    s = json.dumps(serialisable, sort_keys=True, default=str)
+    return hashlib.md5(s.encode()).hexdigest()[:12]

--- a/tests/data/task-repr-design-space-node-clf.yaml
+++ b/tests/data/task-repr-design-space-node-clf.yaml
@@ -1,0 +1,24 @@
+model:
+  num_mp_layers: 1
+  global_pooling: null
+  normalize_adj: [false, true]
+  layer_type: ["gcnconv", "ginconv"]
+  dim_inner: [64, 128]
+  act: ['prelu', 'relu']
+  use_batchnorm: true
+  pooling: null
+  post_mp_dims:
+    - '64,32'
+    - '32, 16'
+train:
+  optim:
+    optimizer: adam
+    base_lr: 0.01
+  lr_schedule:
+    type: null
+  max_epoch: [10, 100]
+data_loader:
+  graph_const: knn
+  knn_k: 20
+  radius_ratio: null
+  batch_size: 32

--- a/tests/task_repr/test_task_repr.py
+++ b/tests/task_repr/test_task_repr.py
@@ -1,0 +1,309 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from stgym.config_schema import NodeClassifierModelConfig
+from stgym.design_space.schema import TaskReprDesignSpace
+from stgym.task_repr import (
+    build_performance_matrix,
+    compute_fingerprints,
+    pairwise_similarity,
+    sample_designs,
+    select_anchor_models,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def node_clf_space():
+    return TaskReprDesignSpace.from_yaml(
+        "tests/data/task-repr-design-space-node-clf.yaml"
+    )
+
+
+def _make_run(design_id, dataset, metric_value, fold=None, status="FINISHED"):
+    tags = {"design_id": str(design_id), "dataset_name": dataset}
+    if fold is not None:
+        tags["fold"] = str(fold)
+    return SimpleNamespace(
+        data=SimpleNamespace(
+            tags=tags,
+            metrics={"test_roc_auc": metric_value},
+        ),
+        info=SimpleNamespace(status=status),
+    )
+
+
+def _make_perf_matrix(n_designs: int, n_tasks: int, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    data = rng.uniform(0, 1, size=(n_designs, n_tasks))
+    return pd.DataFrame(
+        data,
+        index=list(range(n_designs)),
+        columns=[f"task_{i}" for i in range(n_tasks)],
+    )
+
+
+def _make_fp_matrix(scores: dict) -> pd.DataFrame:
+    """scores: {design_id: {task: value}}"""
+    return pd.DataFrame(scores).T
+
+
+# ---------------------------------------------------------------------------
+# sample_designs
+# ---------------------------------------------------------------------------
+
+
+class TestSampleDesigns:
+    @property
+    def task_type(self) -> str:
+        return "node-classification"
+
+    def test_count(self, node_clf_space):
+        designs = sample_designs(node_clf_space, self.task_type, n=5, seed=42)
+        assert len(designs) == 5
+
+    def test_ids_are_sequential(self, node_clf_space):
+        ids = [
+            d[0] for d in sample_designs(node_clf_space, self.task_type, n=4, seed=42)
+        ]
+        assert ids == list(range(4))
+
+    def test_no_task_in_partial(self, node_clf_space):
+        for _, partial in sample_designs(node_clf_space, self.task_type, n=3, seed=42):
+            assert "task" not in partial
+            assert set(partial.keys()) == {"model", "train", "data_loader"}
+
+    def test_model_type_matches_task_type(self, node_clf_space):
+        for _, partial in sample_designs(node_clf_space, self.task_type, n=3, seed=42):
+            assert isinstance(partial["model"], NodeClassifierModelConfig)
+
+    def test_reproducible_with_same_seed(self, node_clf_space):
+        a = sample_designs(node_clf_space, self.task_type, n=5, seed=7)
+        b = sample_designs(node_clf_space, self.task_type, n=5, seed=7)
+        for (id_a, pa), (id_b, pb) in zip(a, b):
+            assert id_a == id_b
+            assert pa["model"].model_dump() == pb["model"].model_dump()
+            assert pa["train"].model_dump() == pb["train"].model_dump()
+            assert pa["data_loader"].model_dump() == pb["data_loader"].model_dump()
+
+    def test_different_seeds_produce_different_configs(self, node_clf_space):
+        a = [
+            pa["model"].model_dump()
+            for _, pa in sample_designs(node_clf_space, self.task_type, n=5, seed=1)
+        ]
+        b = [
+            pb["model"].model_dump()
+            for _, pb in sample_designs(node_clf_space, self.task_type, n=5, seed=2)
+        ]
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# build_performance_matrix
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPerformanceMatrix:
+    @property
+    def simple_runs(self):
+        return [
+            _make_run(0, "brca", 0.8),
+            _make_run(0, "glioblastoma", 0.7),
+            _make_run(1, "brca", 0.6),
+            _make_run(1, "glioblastoma", 0.9),
+        ]
+
+    def test_shape(self):
+        assert build_performance_matrix(self.simple_runs, "test_roc_auc").shape == (
+            2,
+            2,
+        )
+
+    def test_index_and_columns(self):
+        m = build_performance_matrix(self.simple_runs, "test_roc_auc")
+        assert set(m.index) == {0, 1}
+        assert set(m.columns) == {"brca", "glioblastoma"}
+
+    def test_values(self):
+        m = build_performance_matrix(self.simple_runs, "test_roc_auc")
+        assert m.loc[0, "brca"] == pytest.approx(0.8)
+        assert m.loc[1, "glioblastoma"] == pytest.approx(0.9)
+
+    def test_failed_runs_excluded(self):
+        runs = self.simple_runs + [_make_run(2, "brca", 0.5, status="FAILED")]
+        assert 2 not in build_performance_matrix(runs, "test_roc_auc").index
+
+    def test_kfold_aggregated(self):
+        runs = [
+            _make_run(0, "human-intestine", 0.6, fold=0),
+            _make_run(0, "human-intestine", 0.8, fold=1),
+            _make_run(0, "brca", 0.7),
+        ]
+        m = build_performance_matrix(runs, "test_roc_auc", min_task_coverage=0.0)
+        assert m.loc[0, "human-intestine"] == pytest.approx(0.7)
+
+    def test_min_task_coverage_filters_sparse_designs(self):
+        runs = self.simple_runs + [_make_run(2, "brca", 0.5)]
+        assert (
+            2
+            not in build_performance_matrix(
+                runs, "test_roc_auc", min_task_coverage=1.0
+            ).index
+        )
+
+    def test_empty_runs_returns_empty_df(self):
+        assert build_performance_matrix([], "test_roc_auc").empty
+
+    def test_runs_missing_design_id_skipped(self):
+        bad = SimpleNamespace(
+            data=SimpleNamespace(
+                tags={"dataset_name": "brca"},
+                metrics={"test_roc_auc": 0.5},
+            ),
+            info=SimpleNamespace(status="FINISHED"),
+        )
+        assert build_performance_matrix([bad], "test_roc_auc").empty
+
+
+# ---------------------------------------------------------------------------
+# select_anchor_models
+# ---------------------------------------------------------------------------
+
+
+class TestSelectAnchorModels:
+    @property
+    def matrix(self) -> pd.DataFrame:
+        return _make_perf_matrix(n_designs=48, n_tasks=5, seed=42)
+
+    def test_returns_correct_count(self):
+        assert len(select_anchor_models(self.matrix, n_anchors=12)) == 12
+
+    def test_returns_valid_design_ids(self):
+        for a in select_anchor_models(self.matrix, n_anchors=12):
+            assert a in self.matrix.index
+
+    def test_no_duplicate_anchors(self):
+        anchors = select_anchor_models(self.matrix, n_anchors=12)
+        assert len(set(anchors)) == len(anchors)
+
+    def test_anchors_span_performance_range(self):
+        anchors = select_anchor_models(self.matrix, n_anchors=4)
+        avg = self.matrix.mean(axis=1)
+        scores = avg.loc[anchors].sort_values().values
+        overall_median = avg.median()
+        assert scores[0] < overall_median
+        assert scores[-1] > overall_median
+
+    @pytest.mark.parametrize("n_anchors", [1, 4, 12])
+    def test_various_anchor_counts(self, n_anchors):
+        assert len(select_anchor_models(self.matrix, n_anchors=n_anchors)) == n_anchors
+
+    def test_raises_when_too_few_designs(self):
+        with pytest.raises(ValueError, match="Not enough designs"):
+            select_anchor_models(
+                _make_perf_matrix(n_designs=3, n_tasks=2), n_anchors=12
+            )
+
+    def test_deterministic(self):
+        assert select_anchor_models(self.matrix, n_anchors=6) == select_anchor_models(
+            self.matrix, n_anchors=6
+        )
+
+
+# ---------------------------------------------------------------------------
+# compute_fingerprints
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFingerprints:
+    @property
+    def matrix(self) -> pd.DataFrame:
+        return _make_fp_matrix(
+            {
+                0: {"task_a": 0.9, "task_b": 0.5},
+                1: {"task_a": 0.4, "task_b": 0.8},
+                2: {"task_a": 0.6, "task_b": 0.6},
+            }
+        )
+
+    def test_shape(self):
+        assert compute_fingerprints(self.matrix, anchor_ids=[0, 1]).shape == (2, 2)
+
+    def test_index_is_tasks(self):
+        assert set(compute_fingerprints(self.matrix, anchor_ids=[0, 1]).index) == {
+            "task_a",
+            "task_b",
+        }
+
+    def test_columns_are_anchor_ids(self):
+        assert set(compute_fingerprints(self.matrix, anchor_ids=[0, 2]).columns) == {
+            0,
+            2,
+        }
+
+    def test_values_correct(self):
+        fps = compute_fingerprints(self.matrix, anchor_ids=[0])
+        assert fps.loc["task_a", 0] == pytest.approx(0.9)
+        assert fps.loc["task_b", 0] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# pairwise_similarity
+# ---------------------------------------------------------------------------
+
+
+class TestPairwiseSimilarity:
+    @property
+    def three_task_fps(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {"a0": [0.8, 0.3, 0.6], "a1": [0.2, 0.9, 0.4]},
+            index=["t1", "t2", "t3"],
+        )
+
+    @property
+    def identical_fps(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {"a0": [0.9, 0.9], "a1": [0.4, 0.4], "a2": [0.6, 0.6]},
+            index=["task_a", "task_b"],
+        )
+
+    @property
+    def opposite_fps(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {"a0": [0.1, 0.9], "a1": [0.5, 0.5], "a2": [0.9, 0.1]},
+            index=["task_a", "task_b"],
+        )
+
+    def test_diagonal_is_one(self):
+        sim = pairwise_similarity(self.three_task_fps)
+        for task in self.three_task_fps.index:
+            assert sim.loc[task, task] == pytest.approx(1.0)
+
+    def test_symmetric(self):
+        sim = pairwise_similarity(self.three_task_fps)
+        np.testing.assert_allclose(sim.values, sim.values.T)
+
+    def test_identical_rankings_give_one(self):
+        assert pairwise_similarity(self.identical_fps).loc[
+            "task_a", "task_b"
+        ] == pytest.approx(1.0)
+
+    def test_opposite_rankings_give_minus_one(self):
+        assert pairwise_similarity(self.opposite_fps).loc[
+            "task_a", "task_b"
+        ] == pytest.approx(-1.0)
+
+    def test_output_shape(self):
+        assert pairwise_similarity(self.three_task_fps).shape == (3, 3)
+
+    def test_index_and_columns_match_tasks(self):
+        fps = pd.DataFrame({"a0": [0.5, 0.6]}, index=["brca", "glioblastoma"])
+        sim = pairwise_similarity(fps)
+        assert list(sim.index) == ["brca", "glioblastoma"]
+        assert list(sim.columns) == ["brca", "glioblastoma"]


### PR DESCRIPTION
## Problem

No mechanism existed to measure similarity between tasks/datasets. Approach 1.b (re-using existing RCT runs) was ruled out after analysis showed that only 31 of 22,718 design hashes across 26,544 historical runs appeared on more than one task — the random sampling in `design_gen.py` makes collisions near-impossible.

Fixes #193

## Solution

Approach 1.a: a dedicated sweep that runs D fixed designs × T tasks to build a performance matrix, selects M anchor models (bin-by-score + median), and computes pairwise task similarity via Kendall rank correlation.

**Pipeline** (`stgym/task_repr.py`):
1. `sample_designs` — sample D task-free configs from `TaskReprDesignSpace` with a fixed seed
2. `build_performance_matrix` — pivot MLflow runs (tagged `design_id`) into a design × task DataFrame; aggregates k-fold folds automatically
3. `select_anchor_models` — bin designs by average score across tasks, pick median per bin
4. `compute_fingerprints` — task × anchor performance matrix (transpose of anchor rows)
5. `pairwise_similarity` — Kendall tau between every pair of task fingerprint vectors

**Entry-point** (`run_task_repr.py`): Hydra-based, dispatches D×T Ray tasks in one batch. Separate `conf/task_repr/node_clf.yaml` and `graph_clf.yaml` keep design spaces task-type consistent (graph-clf allows pooling; node-clf forbids it).

## Changes

- `stgym/design_space/schema.py` — add `TaskReprDesignSpace` (no `task` field)
- `stgym/task_repr.py` — full pipeline in one file
- `run_task_repr.py` — Hydra entry-point at repo root
- `conf/task_repr_config.yaml` — top-level config (`n_designs=96`, `n_anchors=12`)
- `conf/task_repr/node_clf.yaml` + `graph_clf.yaml` — per-task-type design spaces and dataset lists
- `tests/task_repr/test_task_repr.py` — 33 tests across all five functions
- `tests/data/task-repr-design-space-node-clf.yaml` — test fixture

## Testing

- [ ] `pre-commit run --all-files` passes
- [ ] `pytest tests/ -m 'not slow'` passes (293 tests, 0 failures)
- [ ] 33 new tests cover: count/reproducibility/task-exclusion for sampling; shape/k-fold/coverage-filter for matrix; bin-median logic for anchor selection; shape/index/values for fingerprints; diagonal=1/symmetry/opposite-rankings=-1 for similarity

Co-Authored-By: Claude <noreply@anthropic.com>